### PR TITLE
Build in Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,9 @@ if (HAS_FCOLOR_DIAGNOSTICS)
   add_definitions(-fcolor-diagnostics)
 endif()
 
+if (UNIX)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Wextra")
+endif()
 
 add_subdirectory(lib)
 add_subdirectory(include)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+version: '0.2pre.{build}'
+
+image: Visual Studio 2017
+
+platform:
+  - x64
+
+configuration:
+  - Release
+
+install:
+  - git submodule update --init --recursive
+
+before_build:
+  - cmake -G "Visual Studio 15 2017 Win64" -DLORINA_TEST=ON .
+
+build:
+  project: $(APPVEYOR_BUILD_FOLDER)\$(APPVEYOR_PROJECT_NAME).sln
+
+test_script:
+  - '%APPVEYOR_BUILD_FOLDER%\test\%CONFIGURATION%\run_tests.exe'

--- a/include/lorina/detail/utils.hpp
+++ b/include/lorina/detail/utils.hpp
@@ -36,7 +36,6 @@
 #include <fstream>
 #include <functional>
 #include <functional>
-#include <libgen.h>
 #include <locale>
 #include <memory>
 #include <numeric>
@@ -46,6 +45,7 @@
 #include <unordered_set>
 
 #ifndef _WIN32
+#include <libgen.h>
 #include <wordexp.h>
 #endif
 

--- a/include/lorina/detail/utils.hpp
+++ b/include/lorina/detail/utils.hpp
@@ -44,7 +44,10 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+
+#ifndef _WIN32
 #include <wordexp.h>
+#endif
 
 namespace lorina
 {
@@ -344,28 +347,6 @@ inline std::vector<std::string> split( const std::string& str, const std::string
   return result;
 }
 
-// from http://stackoverflow.com/questions/478898/how-to-execute-a-command-and-get-output-of-command-within-c-using-posix
-inline std::pair<int, std::string> execute_program( const std::string& cmd )
-{
-  char buffer[128];
-  std::string result;
-  int exit_status;
-
-  std::shared_ptr<FILE> pipe( popen( cmd.c_str(), "r" ), [&exit_status]( FILE* fp ) { auto status = pclose( fp ); exit_status = WEXITSTATUS( status ); } );
-  if ( !pipe )
-  {
-    throw std::runtime_error( "[e] popen() failed" );
-  }
-  while ( !feof( pipe.get() ) )
-  {
-    if ( fgets( buffer, 128, pipe.get() ) != NULL )
-    {
-      result += buffer;
-    }
-  }
-  return {exit_status, result};
-}
-
 // based on https://stackoverflow.com/questions/5612182/convert-string-with-explicit-escape-sequence-into-relative-character
 inline std::string unescape_quotes( const std::string& s )
 {
@@ -386,6 +367,7 @@ inline std::string unescape_quotes( const std::string& s )
   return res;
 }
 
+#ifndef _WIN32
 inline std::string word_exp_filename( const std::string& filename )
 {
   std::string result;
@@ -411,6 +393,7 @@ inline std::string basename( const std::string& filepath )
 {
   return std::string( ::basename( const_cast<char*>( filepath.c_str() ) ) );
 }
+#endif
 
 } // namespace detail
 } // namespace lorina

--- a/include/lorina/detail/utils.hpp
+++ b/include/lorina/detail/utils.hpp
@@ -388,7 +388,14 @@ inline std::string word_exp_filename( const std::string& filename )
 
   return result;
 }
+#else
+inline const std::string& word_exp_filename( const std::string& filename )
+{
+  return filename;
+}
+#endif
 
+#ifndef _WIN32
 inline std::string basename( const std::string& filepath )
 {
   return std::string( ::basename( const_cast<char*>( filepath.c_str() ) ) );

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,8 @@
 include_directories(catch2) # v2.0.1
 
+if (UNIX)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O2 -Wall -Wextra")
+endif()
 
 file(GLOB FILENAMES *.cpp)
 

--- a/test/aiger.cpp
+++ b/test/aiger.cpp
@@ -2,7 +2,6 @@
 
 #include <lorina/aiger.hpp>
 #include <fmt/format.h>
-#include <fmt/printf.h>
 #include <map>
 #include <iostream>
 

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -4,8 +4,10 @@
 
 using namespace lorina;
 
+#ifndef _WIN32
 TEST_CASE( "basename", "[utils]" )
 {
   std::string t( "/usr/home/test.cpp" );
   CHECK( "test.cpp" == detail::basename( t ) );
 }
+#endif


### PR DESCRIPTION
This removes the `wordexp` feature for Windows builds and adds an AppVeyor configuration for CI.
