### PR TITLE
Report unresolved dependencies when reading BLIF

### DIFF
--- a/include/lorina/blif.hpp
+++ b/include/lorina/blif.hpp
@@ -292,7 +292,21 @@ inline return_code read_blif( std::istream& in, const blif_reader& reader, diagn
 
       result = return_code::parse_error;
       return true;
-  } );
+    } );
+
+  /* check dangling objects */
+  auto const& deps = on_action.unresolved_dependencies();
+  if ( deps.size() > 0 )
+    result = return_code::parse_error;
+
+  for ( const auto& r : deps )
+  {
+    if ( diag )
+    {
+      diag->report( diagnostic_level::warning,
+                    fmt::format( "unresolved dependencies: `{0}` requires `{1}`",  r.first, r.second ) );
+    }
+  }
 
   return result;
 }


### PR DESCRIPTION
This PR checks for unresolved dependencies when reading a BLIF file. In case of a missing signal, `read_blif` returns `parse_error` and reports each unresolved dependencies to the diagnostic engine.