### PR TITLE
Bugfix: dealing with large numbers of inputs/outputs in BLIF (reported by Max Austin)

### DIFF
--- a/include/lorina/blif.hpp
+++ b/include/lorina/blif.hpp
@@ -170,7 +170,6 @@ public:
 namespace blif_regex
 {
 static std::regex model( R"(.model\s+(.*))" );
-static std::regex inputs( R"(.inputs\s+(.*))" );
 static std::regex outputs( R"(.outputs\s+(.*))" );
 static std::regex names( R"(.names\s+(.*))" );
 static std::regex line_of_truthtable( R"(([01\-]*)\s*([01\-]))" );
@@ -256,9 +255,10 @@ inline return_code read_blif( std::istream& in, const blif_reader& reader, diagn
       }
 
       /* .inputs <list of whitespace separated strings> */
-      if ( std::regex_search( line, m, blif_regex::inputs ) )
+      if ( detail::starts_with( line, ".inputs" ) )
       {
-        for ( const auto& input : detail::split( detail::trim_copy( m[1] ), " " ) )
+        std::string const input_declaration = line.substr( 7 );
+        for ( const auto& input : detail::split( detail::trim_copy( input_declaration ), " " ) )
         {
           auto const s = detail::trim_copy( input );
           on_action.declare_known( s );

--- a/include/lorina/blif.hpp
+++ b/include/lorina/blif.hpp
@@ -170,7 +170,6 @@ public:
 namespace blif_regex
 {
 static std::regex model( R"(.model\s+(.*))" );
-static std::regex outputs( R"(.outputs\s+(.*))" );
 static std::regex names( R"(.names\s+(.*))" );
 static std::regex line_of_truthtable( R"(([01\-]*)\s*([01\-]))" );
 static std::regex end( R"(.end)" );
@@ -268,9 +267,10 @@ inline return_code read_blif( std::istream& in, const blif_reader& reader, diagn
       }
 
       /* .outputs <list of whitespace separated strings> */
-      if ( std::regex_search( line, m, blif_regex::outputs ) )
+      if ( detail::starts_with( line, ".outputs" ) )
       {
-        for ( const auto& output : detail::split( detail::trim_copy( m[1] ), " " ) )
+        std::string const output_declaration = line.substr( 8 );
+        for ( const auto& output : detail::split( detail::trim_copy( output_declaration ), " " ) )
         {
           reader.on_output( detail::trim_copy( output ) );
         }

--- a/include/lorina/detail/utils.hpp
+++ b/include/lorina/detail/utils.hpp
@@ -273,6 +273,11 @@ inline std::string basename( const std::string& filepath )
 }
 #endif
 
+inline bool starts_with( std::string const& s, std::string const& match )
+{
+  return ( s.substr( 0, match.size() ) == match );
+}
+
 } // namespace detail
 } // namespace lorina
 

--- a/test/blif.cpp
+++ b/test/blif.cpp
@@ -143,3 +143,64 @@ TEST_CASE( "gate_types", "[blif]" )
   CHECK( stats.end_seen == true );
   CHECK( stats.equal_size_check == true );
 }
+
+TEST_CASE( "parse large number of inputs", "[blif]" )
+{
+  std::string blif_file_begin =
+      ".model test\n";
+
+  std::string blif_file_end =
+      ".outputs y0\n"
+      ".names y0\n"
+      " 1\n"
+      ".end\n";
+
+  for ( auto i = 0u; i <= 16; ++i )
+  {
+    std::cout << "[i] try with " << ( 1 << i ) << " inputs" << std::endl;
+    std::string input_declaration = ".inputs";
+    for ( auto j = 0; j < ( 1 << i ); ++j )
+    {
+      input_declaration += fmt::format( " x{}", j );
+    }
+    input_declaration += "\n";
+
+    std::istringstream iss( blif_file_begin + input_declaration + blif_file_end );
+
+    blif_statistics stats;
+    blif_statistics_reader reader( stats );
+    auto result = read_blif( iss, reader );
+    CHECK( result == return_code::success );
+  }
+}
+
+TEST_CASE( "parse large number of outputs", "[blif]" )
+{
+  std::string blif_file_begin =
+      ".model test\n"
+      ".inputs x0 x1\n";
+
+  std::string blif_file_end =
+      ".names y0\n"
+      " 1\n"
+      ".end\n";
+
+  for ( auto i = 0u; i <= 16; ++i )
+  {
+    std::cout << "[i] try with " << ( 1 << i ) << " outputs" << std::endl;
+    std::string output_declaration = ".outputs";
+    for ( auto j = 0; j < ( 1 << i ); ++j )
+    {
+      output_declaration += fmt::format( " y{}", j );
+    }
+    output_declaration += "\n";
+
+    std::istringstream iss( blif_file_begin + output_declaration + blif_file_end );
+
+    blif_statistics stats;
+    blif_statistics_reader reader( stats );
+    auto result = read_blif( iss, reader );
+    CHECK( result == return_code::success );
+  }
+}
+


### PR DESCRIPTION
This PR fixes a bug reported by Max Austin, which occurs when large numbers of inputs/outputs have to be parsed by `read_blif`.