### PR TITLE
bench: support for DFFs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     compiler: gcc
     addons:
       apt:
-        sources: 
+        sources:
           - ubuntu-toolchain-r-test
         packages:
           - g++-7
@@ -31,7 +31,7 @@ matrix:
     compiler: gcc
     addons:
       apt:
-        sources: 
+        sources:
           - ubuntu-toolchain-r-test
         packages:
           - g++-7
@@ -59,24 +59,22 @@ matrix:
           - g++-7
     env: COMPILER=clang++-6.0 COVERAGE=OFF
   - os: osx
-    osx_image: xcode9.3
+    osx_image: xcode9.4
     compiler: clang
     before_install:
       - brew update
       - brew install llvm
-    env: COMPILER=/usr/local/opt/llvm/bin/clang++ COVERAGE=OFF
+    env: COMPILER=/usr/local/opt/llvm/bin/clang++
   - os: osx
-    osx_image: xcode8.3
+    osx_image: xcode10.2
     compiler: gcc
     before_install:
-      - brew update
-      - brew install gcc
+      - brew upgrade gcc
     env: COMPILER=/usr/local/opt/gcc/bin/g++-9 COVERAGE=OFF
   - os: osx
-    osx_image: xcode8.3
+    osx_image: xcode10.2
     compiler: gcc
     before_install:
       - brew update
-      - brew install gcc@8
-    env: COMPILER=/usr/local/opt/gcc@8/bin/g++-8 COVERAGE=OFF
-    
+      - brew install gcc@7
+    env: COMPILER=/usr/local/opt/gcc@7/bin/g++-7 COVERAGE=OFF

--- a/include/lorina/detail/utils.hpp
+++ b/include/lorina/detail/utils.hpp
@@ -80,15 +80,18 @@ public:
 
   void declare_known( const std::string& known )
   {
-    _waits_for[ known ];
+    _known.emplace( known );
   }
-  
+
   void call_deferred( const std::vector<std::string>& inputs, const std::string& output, Args... params )
   {
     /* do we have all inputs */
     std::unordered_set<std::string> unknown;
     for ( const auto& input : inputs )
     {
+      if ( _known.find( input ) != _known.end() )
+        continue;
+
       auto it = _waits_for.find( input );
       if ( it == _waits_for.end() || !it->second.empty() )
       {
@@ -149,8 +152,9 @@ public:
     }
     return deps;
   }
-  
+
 private:
+  std::unordered_set<std::string> _known;
   std::unordered_map<std::string, std::unordered_set<std::string>> _triggers;
   std::unordered_map<std::string, std::unordered_set<std::string>> _waits_for;
   std::function<void(Args...)> f;

--- a/test/blif.cpp
+++ b/test/blif.cpp
@@ -157,7 +157,7 @@ TEST_CASE( "parse large number of inputs", "[blif]" )
 
   for ( auto i = 0u; i <= 16; ++i )
   {
-    std::cout << "[i] try with " << ( 1 << i ) << " inputs" << std::endl;
+    // std::cout << "[i] try with " << ( 1 << i ) << " inputs" << std::endl;
     std::string input_declaration = ".inputs";
     for ( auto j = 0; j < ( 1 << i ); ++j )
     {
@@ -187,7 +187,7 @@ TEST_CASE( "parse large number of outputs", "[blif]" )
 
   for ( auto i = 0u; i <= 16; ++i )
   {
-    std::cout << "[i] try with " << ( 1 << i ) << " outputs" << std::endl;
+    // std::cout << "[i] try with " << ( 1 << i ) << " outputs" << std::endl;
     std::string output_declaration = ".outputs";
     for ( auto j = 0; j < ( 1 << i ); ++j )
     {


### PR DESCRIPTION
This PR implements support for DFFs in BENCH and introduces the two new callbacks `on_dff_input` and `on_dff` in lorina's `bench_reader`.