### PR TITLE
some small bugs

### DIFF
--- a/include/lorina/aiger.hpp
+++ b/include/lorina/aiger.hpp
@@ -756,7 +756,7 @@ inline return_code read_aiger( std::istream& in, const aiger_reader& reader, dia
       }
     }
 
-    reader.on_latch( _i + i + 1u, next, init_value );
+    reader.on_latch( _i + i, next, init_value );
   }
 
   for ( auto i = 0u; i < _o; ++i )

--- a/include/lorina/aiger.hpp
+++ b/include/lorina/aiger.hpp
@@ -527,7 +527,7 @@ inline return_code read_ascii_aiger( std::istream& in, const aiger_reader& reade
       {
         init_value = aiger_reader::latch_init_value::ZERO;
       }
-      else if ( tokens[1u] == "1" )
+      else if ( tokens[2u] == "1" )
       {
         init_value = aiger_reader::latch_init_value::ONE;
       }


### PR DESCRIPTION
for ```read_ascii_aiger``` as the code shows, the ```init_value``` is determined by the third token in the latch line
for ```read_aiger```, the ```on_latch``` method is called with a wrong index. If this behavior is correct, maybe the index parameters passed to the ```on_input``` method call for both the ```read_aiger``` and ```read_ascii_aiger``` should start from ```1```.