### PR TITLE
Avoid endless loop in Windows

### DIFF
--- a/include/lorina/aiger.hpp
+++ b/include/lorina/aiger.hpp
@@ -891,7 +891,7 @@ inline return_code read_aiger( std::istream& in, const aiger_reader& reader, dia
  */
 inline return_code read_aiger( const std::string& filename, const aiger_reader& reader, diagnostic_engine* diag = nullptr )
 {
-  std::ifstream in( detail::word_exp_filename( filename ), std::ifstream::in );
+  std::ifstream in( detail::word_exp_filename( filename ), std::ifstream::binary );
   return read_aiger( in, reader, diag );
 }
 


### PR DESCRIPTION
Not reading AIGER files in binary mode, causes an endless loop in the `decode` function in Windows.