### PR TITLE
Declare individual elements of input registers as known

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ if (UNIX)
   if (ENABLE_COVERAGE)
     add_compile_options(-O0 -g --coverage -fprofile-arcs -ftest-coverage)
   endif()
+elseif (WIN32)
+  add_compile_definitions(NOMINMAX=1)
 endif()
 
 add_subdirectory(lib)

--- a/include/lorina/verilog.hpp
+++ b/include/lorina/verilog.hpp
@@ -1070,6 +1070,15 @@ public:
     for ( const auto& i : inputs )
       on_action.declare_known( i );
 
+    if ( std::smatch m; std::regex_match( size, m, verilog_regex::const_size_range ) )
+    {
+      const auto a = std::stoul( m[1].str() );
+      const auto b = std::stoul( m[2].str() );
+      for ( auto j = std::min( a, b ); j <= std::max( a, b ); ++j )
+        for ( const auto& i : inputs )
+          on_action.declare_known( fmt::format( "{}[{}]", i, j ) );
+    }
+
     return true;
   }
 

--- a/include/lorina/verilog_regex.hpp
+++ b/include/lorina/verilog_regex.hpp
@@ -44,6 +44,7 @@ static std::regex binary_expression( R"(^(~)?([[:alnum:]\[\]_']+)([&|^])(~)?([[:
 static std::regex ternary_expression( R"(^(~)?([[:alnum:]\[\]_']+)([&|^])(~)?([[:alnum:]\[\]_']+)([&|^])(~)?([[:alnum:]\[\]_']+)$)" );
 static std::regex maj3_expression( R"(^\((~)?([[:alnum:]\[\]_']+)&(~)?([[:alnum:]\[\]_']+)\)\|\((~)?([[:alnum:]\[\]_']+)&(~)?([[:alnum:]\[\]_']+)\)\|\((~)?([[:alnum:]\[\]_']+)&(~)?([[:alnum:]\[\]_']+)\)$)" );
 static std::regex negated_binary_expression( R"(^~\((~)?([[:alnum:]\[\]_']+)([&|^])(~)?([[:alnum:]\[\]_']+)\)$)" );
+static std::regex const_size_range( R"(^(\d+):(\d+)$)" );
 } // namespace verilog_regex
 
 } // namespace lorina

--- a/test/verilog.cpp
+++ b/test/verilog.cpp
@@ -343,3 +343,46 @@ TEST_CASE( "Module instantiation with parameters", "[verilog]" )
   CHECK( reader._parameter == 2 );
   CHECK( reader._instantiations == 8 );
 }
+
+TEST_CASE( "Input and output registers", "[verilog]" )
+{
+  std::string verilog_file =
+    "module gf24_inversion(x, y);\n"
+    "    input [3:0] x;\n"
+    "    output [3:0] y;\n"
+    "    wire t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13;\n\n"
+    "    assign t1 = x[2] ^ x[3];\n"
+    "    assign t2 = x[2] & x[0];\n"
+    "    assign t3 = x[1] ^ t2;\n"
+    "    assign t4 = x[0] ^ x[1];\n"
+    "    assign t5 = x[3] ^ t2;\n"
+    "    assign t6 = t5 & t4;\n"
+    "    assign t7 = t3 & t1;\n"
+    "    assign t8 = x[0] & x[3];\n"
+    "    assign t9 = t4 & t8;\n"
+    "    assign t10 = t4 ^ t9;\n"
+    "    assign t11 = x[1] & x[2];\n"
+    "    assign t12 = t1 & t11;\n"
+    "    assign t13 = t1 ^ t12;\n"
+    "    assign y[0] = t2 ^ t13;\n"
+    "    assign y[1] = x[3] ^ t7;\n"
+    "    assign y[2] = t2 ^ t10;\n"
+    "    assign y[3] = x[1] ^ t6;\n"
+    "endmodule\n";
+
+  std::istringstream iss( verilog_file );
+  simple_verilog_reader reader;
+  auto result = read_verilog( iss, reader );
+  CHECK( result == return_code::success );
+  CHECK( reader._inputs == 1 );
+  CHECK( reader._outputs == 1 );
+  CHECK( reader._wires == 13 );
+  CHECK( reader._aliases == 0 );
+  CHECK( reader._ands == 7 );
+  CHECK( reader._ors == 0 );
+  CHECK( reader._xors == 10 );
+  CHECK( reader._maj3 == 0 );
+  CHECK( reader._comments == 0 );
+  CHECK( reader._parameter == 0 );
+  CHECK( reader._instantiations == 0 );
+}


### PR DESCRIPTION
In the current implementation of the Verilog parser, only the full input names of registers are declared known, e.g., `x`, which causes problems in the delayed activation of gates, when they contain bit-level access, e.g., `x[0]`. This fixes the problem for constant-size ranges. A test-case is added.

Further, `NOMINMAX` is defined on Windows system to not override C++ std implementation of `min` and `max` with macros.