### PR TITLE
ifstream-related updates

### DIFF
--- a/include/lorina/aiger.hpp
+++ b/include/lorina/aiger.hpp
@@ -673,7 +673,7 @@ inline return_code read_ascii_aiger( const std::string& filename, const aiger_re
   std::ifstream in( detail::word_exp_filename( filename ), std::ifstream::in );
   if ( !in.is_open() )
   {
-    return file_error;
+    return return_code::file_error;
   }
   else
   {
@@ -903,7 +903,7 @@ inline return_code read_aiger( const std::string& filename, const aiger_reader& 
   std::ifstream in( detail::word_exp_filename( filename ), std::ifstream::binary );
   if ( !in.is_open() )
   {
-    return file_error;
+    return return_code::file_error;
   }
   else
   {

--- a/include/lorina/aiger.hpp
+++ b/include/lorina/aiger.hpp
@@ -673,6 +673,11 @@ inline return_code read_ascii_aiger( const std::string& filename, const aiger_re
   std::ifstream in( detail::word_exp_filename( filename ), std::ifstream::in );
   if ( !in.is_open() )
   {
+    if ( diag )
+    {
+      diag->report( diagnostic_level::fatal,
+                    fmt::format( "could not open file `{0}`", filename ) );
+    }
     return return_code::parse_error;
   }
   else
@@ -903,6 +908,11 @@ inline return_code read_aiger( const std::string& filename, const aiger_reader& 
   std::ifstream in( detail::word_exp_filename( filename ), std::ifstream::binary );
   if ( !in.is_open() )
   {
+    if ( diag )
+    {
+      diag->report( diagnostic_level::fatal,
+                    fmt::format( "could not open file `{0}`", filename ) );
+    }
     return return_code::parse_error;
   }
   else

--- a/include/lorina/aiger.hpp
+++ b/include/lorina/aiger.hpp
@@ -673,7 +673,7 @@ inline return_code read_ascii_aiger( const std::string& filename, const aiger_re
   std::ifstream in( detail::word_exp_filename( filename ), std::ifstream::in );
   if ( !in.is_open() )
   {
-    return return_code::file_error;
+    return return_code::parse_error;
   }
   else
   {
@@ -903,7 +903,7 @@ inline return_code read_aiger( const std::string& filename, const aiger_reader& 
   std::ifstream in( detail::word_exp_filename( filename ), std::ifstream::binary );
   if ( !in.is_open() )
   {
-    return return_code::file_error;
+    return return_code::parse_error;
   }
   else
   {

--- a/include/lorina/aiger.hpp
+++ b/include/lorina/aiger.hpp
@@ -671,7 +671,16 @@ inline return_code read_ascii_aiger( std::istream& in, const aiger_reader& reade
 inline return_code read_ascii_aiger( const std::string& filename, const aiger_reader& reader, diagnostic_engine* diag = nullptr )
 {
   std::ifstream in( detail::word_exp_filename( filename ), std::ifstream::in );
-  return read_ascii_aiger( in, reader, diag );
+  if ( !in.is_open() )
+  {
+    return file_error;
+  }
+  else
+  {
+    auto const ret = read_ascii_aiger( in, reader, diag );
+    in.close();
+    return ret;
+  }
 }
 
 /*! \brief Reader function for binary AIGER format.
@@ -892,7 +901,16 @@ inline return_code read_aiger( std::istream& in, const aiger_reader& reader, dia
 inline return_code read_aiger( const std::string& filename, const aiger_reader& reader, diagnostic_engine* diag = nullptr )
 {
   std::ifstream in( detail::word_exp_filename( filename ), std::ifstream::binary );
-  return read_aiger( in, reader, diag );
+  if ( !in.is_open() )
+  {
+    return file_error;
+  }
+  else
+  {
+    auto const ret = read_aiger( in, reader, diag );
+    in.close();
+    return ret;
+  }
 }
 
 } // namespace lorina

--- a/include/lorina/bench.hpp
+++ b/include/lorina/bench.hpp
@@ -301,7 +301,7 @@ inline return_code read_bench( const std::string& filename, const bench_reader& 
   std::ifstream in( detail::word_exp_filename( filename ), std::ifstream::in );
   if ( !in.is_open() )
   {
-    return file_error;
+    return return_code::file_error;
   }
   else
   {

--- a/include/lorina/bench.hpp
+++ b/include/lorina/bench.hpp
@@ -301,6 +301,11 @@ inline return_code read_bench( const std::string& filename, const bench_reader& 
   std::ifstream in( detail::word_exp_filename( filename ), std::ifstream::in );
   if ( !in.is_open() )
   {
+    if ( diag )
+    {
+      diag->report( diagnostic_level::fatal,
+                    fmt::format( "could not open file `{0}`", filename ) );
+    }
     return return_code::parse_error;
   }
   else

--- a/include/lorina/bench.hpp
+++ b/include/lorina/bench.hpp
@@ -301,7 +301,7 @@ inline return_code read_bench( const std::string& filename, const bench_reader& 
   std::ifstream in( detail::word_exp_filename( filename ), std::ifstream::in );
   if ( !in.is_open() )
   {
-    return return_code::file_error;
+    return return_code::parse_error;
   }
   else
   {

--- a/include/lorina/bench.hpp
+++ b/include/lorina/bench.hpp
@@ -299,7 +299,16 @@ inline return_code read_bench( std::istream& in, const bench_reader& reader, dia
 inline return_code read_bench( const std::string& filename, const bench_reader& reader, diagnostic_engine* diag = nullptr )
 {
   std::ifstream in( detail::word_exp_filename( filename ), std::ifstream::in );
-  return read_bench( in, reader, diag );
+  if ( !in.is_open() )
+  {
+    return file_error;
+  }
+  else
+  {
+    auto const ret = read_bench( in, reader, diag );
+    in.close();
+    return ret;
+  }
 }
 
 } // namespace lorina

--- a/include/lorina/blif.hpp
+++ b/include/lorina/blif.hpp
@@ -464,7 +464,7 @@ inline return_code read_blif( const std::string& filename, const blif_reader& re
   std::ifstream in( detail::word_exp_filename( filename ), std::ifstream::in );
   if ( !in.is_open() )
   {
-    return return_code::file_error;
+    return return_code::parse_error;
   }
   else
   {

--- a/include/lorina/blif.hpp
+++ b/include/lorina/blif.hpp
@@ -464,7 +464,7 @@ inline return_code read_blif( const std::string& filename, const blif_reader& re
   std::ifstream in( detail::word_exp_filename( filename ), std::ifstream::in );
   if ( !in.is_open() )
   {
-    return file_error;
+    return return_code::file_error;
   }
   else
   {

--- a/include/lorina/blif.hpp
+++ b/include/lorina/blif.hpp
@@ -464,6 +464,11 @@ inline return_code read_blif( const std::string& filename, const blif_reader& re
   std::ifstream in( detail::word_exp_filename( filename ), std::ifstream::in );
   if ( !in.is_open() )
   {
+    if ( diag )
+    {
+      diag->report( diagnostic_level::fatal,
+                    fmt::format( "could not open file `{0}`", filename ) );
+    }
     return return_code::parse_error;
   }
   else

--- a/include/lorina/blif.hpp
+++ b/include/lorina/blif.hpp
@@ -462,7 +462,16 @@ inline return_code read_blif( std::istream& in, const blif_reader& reader, diagn
 inline return_code read_blif( const std::string& filename, const blif_reader& reader, diagnostic_engine* diag = nullptr )
 {
   std::ifstream in( detail::word_exp_filename( filename ), std::ifstream::in );
-  return read_blif( in, reader, diag );
+  if ( !in.is_open() )
+  {
+    return file_error;
+  }
+  else
+  {
+    auto const ret = read_blif( in, reader, diag );
+    in.close();
+    return ret;
+  }
 }
 
 } // namespace lorina

--- a/include/lorina/bristol.hpp
+++ b/include/lorina/bristol.hpp
@@ -184,11 +184,11 @@ inline return_code read_bristol( std::string const& filename, bristol_reader con
   std::ifstream in( filename, std::ifstream::in );
   if ( !in.is_open() )
   {
-    return return_code::file_error;
+    return return_code::parse_error;
   }
   else
   {
-    auto const ret = read_bristol( in, reader, diag );
+    auto const ret = read_bristol( in, reader );
     in.close();
     return ret;
   }

--- a/include/lorina/bristol.hpp
+++ b/include/lorina/bristol.hpp
@@ -181,7 +181,7 @@ inline return_code read_bristol( std::istream& is, bristol_reader const& reader 
  */
 inline return_code read_bristol( std::string const& filename, bristol_reader const& reader )
 {
-  std::ifstream is( filename, std::ifstream::in );
+  std::ifstream in( filename, std::ifstream::in );
   if ( !in.is_open() )
   {
     return return_code::file_error;

--- a/include/lorina/bristol.hpp
+++ b/include/lorina/bristol.hpp
@@ -184,7 +184,7 @@ inline return_code read_bristol( std::string const& filename, bristol_reader con
   std::ifstream is( filename, std::ifstream::in );
   if ( !in.is_open() )
   {
-    return file_error;
+    return return_code::file_error;
   }
   else
   {

--- a/include/lorina/bristol.hpp
+++ b/include/lorina/bristol.hpp
@@ -182,7 +182,16 @@ inline return_code read_bristol( std::istream& is, bristol_reader const& reader 
 inline return_code read_bristol( std::string const& filename, bristol_reader const& reader )
 {
   std::ifstream is( filename, std::ifstream::in );
-  return read_bristol( is, reader );
+  if ( !in.is_open() )
+  {
+    return file_error;
+  }
+  else
+  {
+    auto const ret = read_bristol( in, reader, diag );
+    in.close();
+    return ret;
+  }
 }
 
 } // namespace lorina

--- a/include/lorina/common.hpp
+++ b/include/lorina/common.hpp
@@ -39,6 +39,7 @@ enum class return_code
 {
   success = 0,
   parse_error,
+  file_error, // cannot open the given filename
 };
 
 } // namespace lorina

--- a/include/lorina/common.hpp
+++ b/include/lorina/common.hpp
@@ -39,7 +39,6 @@ enum class return_code
 {
   success = 0,
   parse_error,
-  file_error, // cannot open the given filename
 };
 
 } // namespace lorina

--- a/include/lorina/dimacs.hpp
+++ b/include/lorina/dimacs.hpp
@@ -200,7 +200,21 @@ inline return_code read_dimacs( std::istream& in, const dimacs_reader& reader, d
 inline return_code read_dimacs( const std::string& filename, const dimacs_reader& reader, diagnostic_engine* diag = nullptr )
 {
   std::ifstream in( detail::word_exp_filename( filename ), std::ifstream::in );
-  return read_dimacs( in, reader, diag );
+  if ( !in.is_open() )
+  {
+    if ( diag )
+    {
+      diag->report( diagnostic_level::fatal,
+                    fmt::format( "could not open file `{0}`", filename ) );
+    }
+    return return_code::parse_error;
+  }
+  else
+  {
+    auto const ret = read_dimacs( in, reader, diag );
+    in.close();
+    return ret;
+  }
 }
 
 } // namespace lorina

--- a/include/lorina/pla.hpp
+++ b/include/lorina/pla.hpp
@@ -344,7 +344,7 @@ inline return_code read_pla( const std::string& filename, const pla_reader& read
   std::ifstream in( detail::word_exp_filename( filename ), std::ifstream::in );
   if ( !in.is_open() )
   {
-    return file_error;
+    return return_code::file_error;
   }
   else
   {

--- a/include/lorina/pla.hpp
+++ b/include/lorina/pla.hpp
@@ -342,7 +342,16 @@ inline return_code read_pla( std::istream& in, const pla_reader& reader, diagnos
 inline return_code read_pla( const std::string& filename, const pla_reader& reader, diagnostic_engine* diag = nullptr )
 {
   std::ifstream in( detail::word_exp_filename( filename ), std::ifstream::in );
-  return read_pla( in, reader, diag );
+  if ( !in.is_open() )
+  {
+    return file_error;
+  }
+  else
+  {
+    auto const ret = read_pla( in, reader, diag );
+    in.close();
+    return ret;
+  }
 }
 
 } // namespace lorina

--- a/include/lorina/pla.hpp
+++ b/include/lorina/pla.hpp
@@ -344,6 +344,11 @@ inline return_code read_pla( const std::string& filename, const pla_reader& read
   std::ifstream in( detail::word_exp_filename( filename ), std::ifstream::in );
   if ( !in.is_open() )
   {
+    if ( diag )
+    {
+      diag->report( diagnostic_level::fatal,
+                    fmt::format( "could not open file `{0}`", filename ) );
+    }
     return return_code::parse_error;
   }
   else

--- a/include/lorina/pla.hpp
+++ b/include/lorina/pla.hpp
@@ -344,7 +344,7 @@ inline return_code read_pla( const std::string& filename, const pla_reader& read
   std::ifstream in( detail::word_exp_filename( filename ), std::ifstream::in );
   if ( !in.is_open() )
   {
-    return return_code::file_error;
+    return return_code::parse_error;
   }
   else
   {

--- a/include/lorina/verilog.hpp
+++ b/include/lorina/verilog.hpp
@@ -1461,7 +1461,7 @@ inline return_code read_verilog( const std::string& filename, const verilog_read
   std::ifstream in( detail::word_exp_filename( filename ), std::ifstream::in );
   if ( !in.is_open() )
   {
-    return return_code::file_error;
+    return return_code::parse_error;
   }
   else
   {

--- a/include/lorina/verilog.hpp
+++ b/include/lorina/verilog.hpp
@@ -1459,7 +1459,16 @@ inline return_code read_verilog( std::istream& in, const verilog_reader& reader,
 inline return_code read_verilog( const std::string& filename, const verilog_reader& reader, diagnostic_engine* diag = nullptr )
 {
   std::ifstream in( detail::word_exp_filename( filename ), std::ifstream::in );
-  return read_verilog( in, reader, diag );
+  if ( !in.is_open() )
+  {
+    return file_error;
+  }
+  else
+  {
+    auto const ret = read_verilog( in, reader, diag );
+    in.close();
+    return ret;
+  }
 }
 
 } // namespace lorina

--- a/include/lorina/verilog.hpp
+++ b/include/lorina/verilog.hpp
@@ -1461,6 +1461,11 @@ inline return_code read_verilog( const std::string& filename, const verilog_read
   std::ifstream in( detail::word_exp_filename( filename ), std::ifstream::in );
   if ( !in.is_open() )
   {
+    if ( diag )
+    {
+      diag->report( diagnostic_level::fatal,
+                    fmt::format( "could not open file `{0}`", filename ) );
+    }
     return return_code::parse_error;
   }
   else

--- a/include/lorina/verilog.hpp
+++ b/include/lorina/verilog.hpp
@@ -1461,7 +1461,7 @@ inline return_code read_verilog( const std::string& filename, const verilog_read
   std::ifstream in( detail::word_exp_filename( filename ), std::ifstream::in );
   if ( !in.is_open() )
   {
-    return file_error;
+    return return_code::file_error;
   }
   else
   {


### PR DESCRIPTION
- A parse error (and diagnostic) is reported if a file stream could not be opened (before parsing).
- File streams are closed after parsing.