### PR TITLE
genlib: support for PIN specifications.

### DIFF
--- a/include/lorina/genlib.hpp
+++ b/include/lorina/genlib.hpp
@@ -144,25 +144,28 @@ private:
       }
     }
 
-    if ( diag && tokens.size() < 4u )
+    if ( tokens.size() < 4u )
     {
-      diag->report( diagnostic_level::error, fmt::format( "line `{}` has unexpected structure (expected `GATE <name> <area> <expression>;`)`",
-                                                          line ) );
+      if ( diag )
+        diag->report( diagnostic_level::error, fmt::format( "line `{}` has unexpected structure (expected `GATE <name> <area> <expression>;`)`",
+                                                            line ) );
       return false;
     }
 
-    if ( diag && tokens[0] != "GATE" )
+    if ( tokens[0] != "GATE" )
     {
-      diag->report( diagnostic_level::error, fmt::format( "line `{}` does not start with keyword `GATE`",
-                                                          line ) );
+      if ( diag )
+        diag->report( diagnostic_level::error, fmt::format( "line `{}` does not start with keyword `GATE`",
+                                                            line ) );
       return false;
     }
     auto const beg = tokens[3].find_first_of( "=" );
     auto const end = tokens[3].find_first_of( ";" );
-    if ( diag && ( beg == std::string::npos || end == std::string::npos ) )
+    if ( beg == std::string::npos || end == std::string::npos )
     {
-      diag->report( diagnostic_level::error, fmt::format( "expression `{}` is not immediately terminated with `;``",
-                                                          tokens[3] ) );
+      if ( diag )
+        diag->report( diagnostic_level::error, fmt::format( "expression `{}` is not immediately terminated with `;``",
+                                                            tokens[3] ) );
       return false;
     }
 
@@ -176,10 +179,11 @@ private:
     for ( ; i+8 < tokens.size(); i += 9 )
     {
       /* check PIN specification */
-      if ( diag && tokens[i] != "PIN" )
+      if ( tokens[i] != "PIN" )
       {
-        diag->report( diagnostic_level::error, fmt::format( "unexpected `{}` token (expected `PIN`)",
-                                                            tokens[i] ) );
+        if ( diag )
+          diag->report( diagnostic_level::error, fmt::format( "unexpected `{}` token (expected `PIN`)",
+                                                              tokens[i] ) );
         return false;
       }
 
@@ -195,10 +199,11 @@ private:
       }
       else
       {
-        if ( diag && tokens[i+2] != "UNKNOWN" )
+        if ( tokens[i+2] != "UNKNOWN" )
         {
-          diag->report( diagnostic_level::warning, fmt::format( "unknown PIN phase type `{}` (expected `INV`, `NONINV`, or `UNKNOWN`)",
-                                                                tokens[i+1] ) );
+          if ( diag )
+            diag->report( diagnostic_level::warning, fmt::format( "unknown PIN phase type `{}` (expected `INV`, `NONINV`, or `UNKNOWN`)",
+                                                                  tokens[i+1] ) );
         }
       }
 
@@ -212,10 +217,11 @@ private:
       pins.emplace_back( pin_spec{name,phase,input_load,max_load,rise_block_delay,rise_fanout_delay,fall_block_delay,fall_fanout_delay} );
     }
 
-    if ( diag && i != tokens.size() )
+    if ( i != tokens.size() )
     {
-      diag->report( diagnostic_level::error, fmt::format( "parsing failed at token `{}`",
-                                                          tokens[i] ) );
+      if ( diag )
+        diag->report( diagnostic_level::error, fmt::format( "parsing failed at token `{}`",
+                                                            tokens[i] ) );
       return false;
     }
 

--- a/include/lorina/genlib.hpp
+++ b/include/lorina/genlib.hpp
@@ -45,6 +45,26 @@
 namespace lorina
 {
 
+enum class phase_type : uint8_t
+{
+  INV = 0,
+  NONINV = 1,
+  UNKNOWN = 2,
+};
+
+// PIN <pin-name> <phase> <input-load> <max-load> <rise-block-delay> <rise-fanout-delay> <fall-block-delay> <fall-fanout-delay>
+struct pin_spec
+{
+  std::string name;
+  phase_type phase;
+  double input_load;
+  double max_load;
+  double rise_block_delay;
+  double rise_fanout_delay;
+  double fall_block_delay;
+  double fall_fanout_delay;
+}; /* pin_spec */
+
 /*! \brief A reader visitor for a GENLIB format.
  *
  * Callbacks for the GENLIB format.
@@ -52,12 +72,12 @@ namespace lorina
 class genlib_reader
 {
 public:
-  virtual void on_gate( std::string const& name, std::string const& expression, double area, std::optional<double> delay ) const
+  virtual void on_gate( std::string const& name, std::string const& expression, double area, std::vector<pin_spec> const& pins ) const
   {
     (void)name;
     (void)expression;
     (void)area;
-    (void)delay;
+    (void)pins;
   }
 }; /* genlib_reader */
 
@@ -149,25 +169,57 @@ private:
     std::string const& name = tokens[1];
     std::string const& expression = tokens[3].substr( beg + 1, end - beg - 1 );
     double const area = std::stod( tokens[2] );
-    if ( tokens.size() > 4u )
+
+    std::vector<pin_spec> pins;
+
+    uint64_t i{4};
+    for ( ; i+8 < tokens.size(); i += 9 )
     {
-      /* find delay information for gate */
-      double delay{0.0};
-      for ( auto i = 4u; i < tokens.size(); ++i )
+      /* check PIN specification */
+      if ( diag && tokens[i] != "PIN" )
       {
-        if ( tokens[i] == "PIN" )
+        diag->report( diagnostic_level::error, fmt::format( "unexpected `{}` token (expected `PIN`)",
+                                                            tokens[i] ) );
+        return false;
+      }
+
+      std::string const& name = tokens[i+1];
+      phase_type phase{phase_type::UNKNOWN};
+      if ( tokens[i+2] == "INV" )
+      {
+        phase = phase_type::INV;
+      }
+      else if ( tokens[i+2] == "NONINV" )
+      {
+        phase = phase_type::NONINV;
+      }
+      else
+      {
+        if ( diag && tokens[i+2] != "UNKNOWN" )
         {
-          delay = std::stod( tokens[ i + 3 ] );
+          diag->report( diagnostic_level::warning, fmt::format( "unknown PIN phase type `{}` (expected `INV`, `NONINV`, or `UNKNOWN`)",
+                                                                tokens[i+1] ) );
         }
       }
 
-      reader.on_gate( name, expression, area, delay );
-    }
-    else
-    {
-      reader.on_gate( name, expression, area, std::nullopt );
+      double const input_load = std::stod( tokens[i+3] );
+      double const max_load = std::stod( tokens[i+4] );
+      double const rise_block_delay = std::stod( tokens[i+5] );
+      double const rise_fanout_delay = std::stod( tokens[i+6] );
+      double const fall_block_delay = std::stod( tokens[i+7] );
+      double const fall_fanout_delay = std::stod( tokens[i+8] );
+
+      pins.emplace_back( pin_spec{name,phase,input_load,max_load,rise_block_delay,rise_fanout_delay,fall_block_delay,fall_fanout_delay} );
     }
 
+    if ( diag && i != tokens.size() )
+    {
+      diag->report( diagnostic_level::error, fmt::format( "parsing failed at token `{}`",
+                                                          tokens[i] ) );
+      return false;
+    }
+
+    reader.on_gate( name, expression, area, pins );
     return true;
   }
 

--- a/test/genlib.cpp
+++ b/test/genlib.cpp
@@ -9,7 +9,7 @@ struct gate
   std::string name;
   std::string expression;
   double area;
-  double delay;
+  std::vector<pin_spec> pins;
 };
 
 struct test_reader : public genlib_reader
@@ -19,9 +19,9 @@ public:
     : gates( gates )
   {}
 
-  void on_gate( std::string const& name, std::string const& expression, double area, std::optional<double> delay ) const
+  void on_gate( std::string const& name, std::string const& expression, double area, std::vector<pin_spec> const& pins ) const
   {
-    gates.emplace_back( gate{name, expression, area, delay ? *delay : 0.0} );
+    gates.emplace_back( gate{name, expression, area, pins} );
   }
 
 public:
@@ -47,20 +47,67 @@ TEST_CASE( "GENLIB", "[genlib]")
   CHECK( gate_definitions[0u].name == "zero" );
   CHECK( gate_definitions[0u].expression == "0" );
   CHECK( gate_definitions[0u].area == 0.0 );
-  CHECK( gate_definitions[0u].delay == 0.0 );
+  CHECK( gate_definitions[0u].pins.empty() );
 
   CHECK( gate_definitions[1u].name == "one" );
   CHECK( gate_definitions[1u].expression == "1" );
   CHECK( gate_definitions[1u].area == 0.0 );
-  CHECK( gate_definitions[1u].delay == 0.0 );
+  CHECK( gate_definitions[1u].pins.empty() );
 
   CHECK( gate_definitions[2u].name == "inv1" );
   CHECK( gate_definitions[2u].expression == "!a" );
   CHECK( gate_definitions[2u].area == 1.0 );
-  CHECK( gate_definitions[2u].delay == 1.0 );
+  CHECK( gate_definitions[2u].pins.size() == 1u );
 
   CHECK( gate_definitions[3u].name == "buf" );
   CHECK( gate_definitions[3u].expression == "a" );
   CHECK( gate_definitions[3u].area == 2.0 );
-  CHECK( gate_definitions[3u].delay == 1.0 );
+  CHECK( gate_definitions[3u].pins.size() == 1u );
+}
+
+TEST_CASE( "PIN specification", "[genlib]")
+{
+  std::string const genlib_file =
+    "GATE and2 1 O=a*b; PIN a INV 1.0 2.0 1.1 1.2 1.3 1.4 PIN b INV 1.0 2.0 1.0 1.0 1.0 1.0;\n"
+    "GATE and3 1 O=a*b*c; PIN * UNKNOWN 1.0 2.0 1.0 1.0 1.0 1.0;\n"
+    ;
+
+  diagnostic_engine diag;
+  std::istringstream iss( genlib_file );
+  std::vector<gate> gate_definitions;
+  test_reader reader( gate_definitions );
+  CHECK( read_genlib( iss, reader, &diag ) == return_code::success );
+
+  CHECK( gate_definitions.size() == 2u );
+
+  /* first gate */
+  CHECK( gate_definitions[0u].pins.size() == 2u );
+  CHECK( gate_definitions[0u].pins[0u].name == "a" );
+  CHECK( gate_definitions[0u].pins[0u].phase == phase_type::INV );
+  CHECK( gate_definitions[0u].pins[0u].input_load == 1.0 );
+  CHECK( gate_definitions[0u].pins[0u].max_load == 2.0 );
+  CHECK( gate_definitions[0u].pins[0u].rise_block_delay == 1.1 );
+  CHECK( gate_definitions[0u].pins[0u].rise_fanout_delay == 1.2 );
+  CHECK( gate_definitions[0u].pins[0u].fall_block_delay == 1.3 );
+  CHECK( gate_definitions[0u].pins[0u].fall_fanout_delay == 1.4 );
+
+  CHECK( gate_definitions[0u].pins[1u].name == "b" );
+  CHECK( gate_definitions[0u].pins[1u].phase == phase_type::INV );
+  CHECK( gate_definitions[0u].pins[1u].input_load == 1.0 );
+  CHECK( gate_definitions[0u].pins[1u].max_load == 2.0 );
+  CHECK( gate_definitions[0u].pins[1u].rise_block_delay == 1.0 );
+  CHECK( gate_definitions[0u].pins[1u].rise_fanout_delay == 1.0 );
+  CHECK( gate_definitions[0u].pins[1u].fall_block_delay == 1.0 );
+  CHECK( gate_definitions[0u].pins[1u].fall_fanout_delay == 1.0 );
+
+  /* second gate */
+  CHECK( gate_definitions[1u].pins.size() == 1u );
+  CHECK( gate_definitions[1u].pins[0u].name == "*" );
+  CHECK( gate_definitions[1u].pins[0u].phase == phase_type::UNKNOWN );
+  CHECK( gate_definitions[1u].pins[0u].input_load == 1.0 );
+  CHECK( gate_definitions[1u].pins[0u].max_load == 2.0 );
+  CHECK( gate_definitions[1u].pins[0u].rise_block_delay == 1.0 );
+  CHECK( gate_definitions[1u].pins[0u].rise_fanout_delay == 1.0 );
+  CHECK( gate_definitions[1u].pins[0u].fall_block_delay == 1.0 );
+  CHECK( gate_definitions[1u].pins[0u].fall_fanout_delay == 1.0 );
 }

--- a/test/genlib.cpp
+++ b/test/genlib.cpp
@@ -51,42 +51,48 @@ TEST_CASE( "error cases", "[genlib]")
     /* not all required fields have been specified */
     std::string const genlib_file = "GATE zero";
     std::istringstream iss( genlib_file );
-    CHECK( read_genlib( iss, genlib_reader{} ) == return_code::parse_error );
+    silent_diagnostic_engine diag;
+    CHECK( read_genlib( iss, genlib_reader{}, &diag ) == return_code::parse_error );
   }
 
   {
     /* the keyword `GATE` in the beginning is missing */
     std::string const genlib_file = "zero 0 O=0; PIN * INV 1 999 1 1 1 1";
     std::istringstream iss( genlib_file );
-    CHECK( read_genlib( iss, genlib_reader{} ) == return_code::parse_error );
+    silent_diagnostic_engine diag;
+    CHECK( read_genlib( iss, genlib_reader{}, &diag ) == return_code::parse_error );
   }
 
   {
     /* the expression is not terminated by a semicolon */
     std::string const genlib_file = "GATE zero 0 O=0 PIN * INV 1 999 1 1 1 1";
     std::istringstream iss( genlib_file );
-    CHECK( read_genlib( iss, genlib_reader{} ) == return_code::parse_error );
+    silent_diagnostic_engine diag;
+    CHECK( read_genlib( iss, genlib_reader{}, &diag ) == return_code::parse_error );
   }
 
   {
     /* the pin specification does not start with the keyword `PIN` */
     std::string const genlib_file = "GATE zero 0 O=0; a INV 1 999 1 1 1 1 1";
     std::istringstream iss( genlib_file );
-    CHECK( read_genlib( iss, genlib_reader{} ) == return_code::parse_error );
+    silent_diagnostic_engine diag;
+    CHECK( read_genlib( iss, genlib_reader{}, &diag ) == return_code::parse_error );
   }
 
   {
     /* the phase has been specified with an unknown keyword (NONINV is misspelled)  */
     std::string const genlib_file = "GATE zero 0 O=0; PIN * NOINV 1 999 1 1 1 1\n";
     std::istringstream iss( genlib_file );
-    CHECK( read_genlib( iss, genlib_reader{} ) == return_code::success );
+    silent_diagnostic_engine diag;
+    CHECK( read_genlib( iss, genlib_reader{}, &diag ) == return_code::success );
   }
 
   {
     /* the PIN spec is incomplete and not all tokens are consumed  */
-    std::string const genlib_file = "GATE zero 0 O=0 PIN a 1";
+    std::string const genlib_file = "GATE zero 0 O=0; PIN a 1";
     std::istringstream iss( genlib_file );
-    CHECK( read_genlib( iss, genlib_reader{} ) == return_code::parse_error );
+    silent_diagnostic_engine diag;
+    CHECK( read_genlib( iss, genlib_reader{}, &diag ) == return_code::parse_error );
   }
 }
 


### PR DESCRIPTION
This PR implements support for PIN specifications as described in the GENLIB format [1] parser.

[1] https://people.eecs.berkeley.edu/~alanmi/publications/other/SIS_paper_genlib.pdf