### PR TITLE
Reading and writing Verilog with module instantiation

### DIFF
--- a/include/lorina/verilog.hpp
+++ b/include/lorina/verilog.hpp
@@ -646,6 +646,39 @@ public:
     _os << "endmodule" << std::endl;
   }
 
+  /*! \brief Callback method for writing a module instantiation.
+   *
+   * \param module_name Module name
+   * \param params List of parameters
+   * \param inst_name Instance name
+   * \param args List of arguments (first: I/O pin name, second: wire name)
+   */
+  virtual void on_module_instantiation( std::string const& module_name, std::vector<std::string> const& params, std::string const& inst_name,
+                                        std::vector<std::pair<std::string,std::string>> const& args ) const
+  {
+    _os << fmt::format( "  {} ", module_name );
+    if ( params.size() > 0u )
+    {
+      _os << "#(";
+      for ( auto i = 0u; i < params.size(); ++i )
+      {
+        _os << params.at( i );
+        if ( i + 1 < params.size() )
+          _os << ", ";
+      }
+      _os << ")";
+    }
+
+    _os << fmt::format( " {}( ", inst_name );
+    for ( auto i = 0u; i < args.size(); ++i )
+    {
+      _os << fmt::format( ".{} ({})", args.at( i ).first, args.at( i ).second );
+      if ( i + 1 < args.size() )
+        _os << ", ";
+    }
+    _os << " );\n";
+  }
+
   /*! \brief Callback method for writing an assignment statement.
    *
    * \param out Output signal
@@ -1261,7 +1294,7 @@ public:
     do
     {
       valid = get_token( token );
-      if ( !valid ) return false; // referes to signal
+      if ( !valid ) return false; // refers to signal
       auto const arg0 = token;
 
       valid = get_token( token );
@@ -1278,6 +1311,10 @@ public:
       if ( !valid ) return false;
 
       args.emplace_back( std::make_pair( arg0, arg1 ) );
+      if ( arg0 == ".o" )
+      {
+        on_action.declare_known( arg1 );
+      }
     } while ( token == "," );
 
     if ( !valid || token != ")" ) return false;

--- a/test/verilog.cpp
+++ b/test/verilog.cpp
@@ -402,7 +402,7 @@ TEST_CASE( "Module instantiation with parameters", "[verilog]" )
     "endmodule\n"
     "module mod_add( x1 , x2 , y1 );\n"
     "  input x1, x2 ;\n"
-    "  output o;\n"
+    "  output y1 ;\n"
     "endmodule\n"
     "module mod_sub( x1 , x2 , y1 );\n"
     "  input x1 , x2 ;\n"

--- a/test/verilog.cpp
+++ b/test/verilog.cpp
@@ -471,3 +471,34 @@ TEST_CASE( "Input and output registers", "[verilog]" )
   CHECK( reader._parameter == 0 );
   CHECK( reader._instantiations == 0 );
 }
+
+TEST_CASE( "Module instantiation without parameters and with output logic", "[verilog]" )
+{
+  std::string const verilog_file =
+    "module buffer( i , o );\n"
+    "  input i;\n"
+    "  output o;\n"
+    "endmodule\n"
+    "module inverter( i , o );\n"
+    "  input i;\n"
+    "  output o;\n"
+    "endmodule\n"
+    "module top( x0 , x1 , y0 );\n"
+    "  input x0 , x1 ;\n"
+    "  output y0 ;\n"
+    "  wire n5 ;\n"
+    "  buffer  buf_n3( .i (x0), .o (n3) );\n"
+    "  buffer  buf_n4( .i (n3), .o (n4) );\n"
+    "  assign n5 = ~x1 & ~n4 ;\n"
+    "  inverter  inv_n6( n5, n6 );\n"
+    "  assign y0 = n6 ;\n"
+    "endmodule\n";
+
+  std::istringstream iss( verilog_file );
+  simple_verilog_reader reader;
+  auto result = read_verilog( iss, reader );
+  CHECK( result == return_code::success );
+  CHECK( reader._inputs == 2 );
+  CHECK( reader._outputs == 1 );
+  CHECK( reader._instantiations == 3 );
+}

--- a/test/verilog.cpp
+++ b/test/verilog.cpp
@@ -508,13 +508,16 @@ TEST_CASE( "Module instantiation without parameters and with output logic", "[ve
     "  buffer  buf_n3( .i (x0), .o (n3) );\n"
     "  buffer  buf_n4( .i (n3), .o (n4) );\n"
     "  assign n5 = ~x1 & ~n4 ;\n"
-    "  inverter  inv_n6( n5, n6 );\n"
+    "  inverter  inv_n6( .i (n5), .o (n6) );\n"
     "  assign y0 = n6 ;\n"
     "endmodule\n";
 
+  lorina::text_diagnostics consumer;
+  lorina::diagnostic_engine diag( &consumer );
+
   std::istringstream iss( verilog_file );
   simple_verilog_reader reader;
-  auto result = read_verilog( iss, reader );
+  auto result = read_verilog( iss, reader, &diag );
   CHECK( result == return_code::success );
   CHECK( reader._inputs == 2 );
   CHECK( reader._outputs == 1 );

--- a/test/verilog.cpp
+++ b/test/verilog.cpp
@@ -486,7 +486,7 @@ TEST_CASE( "Module instantiation without parameters and with output logic", "[ve
     "module top( x0 , x1 , y0 );\n"
     "  input x0 , x1 ;\n"
     "  output y0 ;\n"
-    "  wire n5 ;\n"
+    "  wire n3 , n4 , n5 , n6 ;\n"
     "  buffer  buf_n3( .i (x0), .o (n3) );\n"
     "  buffer  buf_n4( .i (n3), .o (n4) );\n"
     "  assign n5 = ~x1 & ~n4 ;\n"


### PR DESCRIPTION
- Adds function `on_module_instantiation` in `verilog_writer` to write Verilog files with module instantiation.
- Adds test case for module instantiation.

=====
The test case was failing because (fixed in #59):
- Cannot parse multiple modules (top-level design with submodules).
- Error when parsing module instantiation without parameters (the `#(params...)` syntax).
- When a submodule's output is used in RHS expressions, it needs to be `declare_known` in module instantiation. 