### PR TITLE
Make the DIMACS clause regex more robust

### DIFF
--- a/include/lorina/dimacs.hpp
+++ b/include/lorina/dimacs.hpp
@@ -99,7 +99,7 @@ public:
 namespace dimacs_regex
 {
 static std::regex problem_spec( R"(^p\s+([cd]nf)\s+([0-9]+)\s+([0-9]+)$)" );
-static std::regex clause( R"(((-?[1-9]+)+ +)+0)" );
+static std::regex clause( R"(((-?[1-9][0-9]*)+ +)+0)" );
 
 } // namespace dimacs_regex
 

--- a/test/dimacs.cpp
+++ b/test/dimacs.cpp
@@ -121,6 +121,33 @@ TEST_CASE( "cnf_dimacs single line of clauses", "[dimacs]" )
   CHECK( stats.variable_appearance_count == expected );
 }
 
+TEST_CASE( "cnf_dimacs variables ending with 0", "[dimacs]" )
+{
+  std::string const dimacs =
+  "c\n"
+  "c start with comments\n"
+  "c\n"
+  "c\n"
+  "p cnf 10 2\n"
+  "1 -10 8 0\n"
+  "-2 3 10 0\n";
+  
+  std::istringstream iss( dimacs );
+  
+  dimacs_statistics stats;
+  dimacs_statistics_reader reader( stats );
+  diagnostic_consumer consumer;
+  diagnostic_engine diag( &consumer );
+  auto const result = read_dimacs( iss, reader, &diag );
+  
+  CHECK( result == return_code::success );
+  CHECK( stats.format == "cnf" );
+  CHECK( stats.number_of_variables == 10 );
+  CHECK( stats.number_of_clauses == 2 );
+  std::vector<uint32_t> const expected = { 1, 1, 1, 0, 0, 0, 0, 1, 0, 2 };
+  CHECK( stats.variable_appearance_count == expected );
+}
+
 TEST_CASE( "cnf_dimacs missing problem specification", "[dimacs]" )
 {
   std::string const dimacs =


### PR DESCRIPTION
#### Description

The regex `(((-?[1-9]+)+ +)+0)` for a DIMACS clause was changed to `(((-?[1-9][0-9]*)+ +)+0)` to make it more robust and allow variable indices ending with 0.

This change was motivated by the fact that originally variable indices ending with 0 were not possible. For example, the following lines caused a *parse error*:

```cnf
p cnf 100 430
...
-3 45 40 0
...
```

#### Tests

I tested the original regex [here](https://regex101.com/r/vlAPmF/1). The behavior using the new regex can be seen [here](https://regex101.com/r/yBGMo8/1).