### PR TITLE
Verilog parser

### DIFF
--- a/include/lorina/verilog/ast_graph.hpp
+++ b/include/lorina/verilog/ast_graph.hpp
@@ -611,10 +611,12 @@ public:
     assert( identifier_list < nodes_.size() );
     if ( const ast_identifier_list* node = dynamic_cast<ast_identifier_list*>( nodes_[identifier_list] ) )
     {
+      (void)node;
       return create_node<ast_input_declaration>( node->identifiers() );
     }
     else if ( const ast_identifier* node = dynamic_cast<ast_identifier*>( nodes_[identifier_list] ) )
     {
+      (void)node;
       return create_node<ast_input_declaration>( std::vector<ast_id>( identifier_list ) );
     }
     else
@@ -631,10 +633,12 @@ public:
     const ast_range_expression* range_expr = static_cast<ast_range_expression*>( nodes_[range] );
     if ( const ast_identifier_list* node = dynamic_cast<ast_identifier_list*>( nodes_[identifier_list] ) )
     {
+      (void)node;
       return create_node<ast_input_declaration>( node->identifiers(), range_expr->hi(), range_expr->lo() );
     }
     else if ( const ast_identifier* node = dynamic_cast<ast_identifier*>( nodes_[identifier_list] ) )
     {
+      (void)node;
       return create_node<ast_input_declaration>( std::vector<ast_id>( identifier_list ), range_expr->hi(), range_expr->lo() );
     }
     else
@@ -649,10 +653,12 @@ public:
     assert( identifier_list < nodes_.size() );
     if ( const ast_identifier_list* node = dynamic_cast<ast_identifier_list*>( nodes_[identifier_list] ) )
     {
+      (void)node;
       return create_node<ast_output_declaration>( node->identifiers() );
     }
     else if ( const ast_identifier* node = dynamic_cast<ast_identifier*>( nodes_[identifier_list] ) )
     {
+      (void)node;
       return create_node<ast_output_declaration>( std::vector<ast_id>( identifier_list ) );
     }
     else
@@ -669,10 +675,12 @@ public:
     const ast_range_expression* range_expr = static_cast<ast_range_expression*>( nodes_[range] );
     if ( const ast_identifier_list* node = dynamic_cast<ast_identifier_list*>( nodes_[identifier_list] ) )
     {
+      (void)node;
       return create_node<ast_output_declaration>( node->identifiers(), range_expr->hi(), range_expr->lo() );
     }
     else if ( const ast_identifier* node = dynamic_cast<ast_identifier*>( nodes_[identifier_list] ) )
     {
+      (void)node;
       return create_node<ast_output_declaration>( std::vector<ast_id>( identifier_list ), range_expr->hi(), range_expr->lo() );
     }
     else
@@ -687,10 +695,12 @@ public:
     assert( identifier_list < nodes_.size() );
     if ( const ast_identifier_list* node = dynamic_cast<ast_identifier_list*>( nodes_[identifier_list] ) )
     {
+      (void)node;
       return create_node<ast_wire_declaration>( node->identifiers() );
     }
     else if ( const ast_identifier* node = dynamic_cast<ast_identifier*>( nodes_[identifier_list] ) )
     {
+      (void)node;
       return create_node<ast_wire_declaration>( std::vector<ast_id>( identifier_list ) );
     }
     else
@@ -707,10 +717,12 @@ public:
     const ast_range_expression* range_expr = static_cast<ast_range_expression*>( nodes_[range] );
     if ( const ast_identifier_list* node = dynamic_cast<ast_identifier_list*>( nodes_[identifier_list] ) )
     {
+      (void)node;
       return create_node<ast_wire_declaration>( node->identifiers(), range_expr->hi(), range_expr->lo() );
     }
     else if ( const ast_identifier* node = dynamic_cast<ast_identifier*>( nodes_[identifier_list] ) )
     {
+      (void)node;
       return create_node<ast_wire_declaration>( std::vector<ast_id>( identifier_list ), range_expr->hi(), range_expr->lo() );
     }
     else

--- a/include/lorina/verilog/ast_graph.hpp
+++ b/include/lorina/verilog/ast_graph.hpp
@@ -113,6 +113,36 @@ protected:
   std::vector<ast_id> identifiers_;
 }; // ast_identifier_list
 
+/* \brief Array select
+ *
+ * An identifier followed by an bit selector of form
+ *   IDENTIFIER `[` NUMERAL `]`
+ *
+ */
+class ast_array_select : public ast_node
+{
+public:
+  explicit ast_array_select( ast_id array, ast_id index )
+    : array_( array )
+    , index_( index )
+  {
+  }
+
+  inline ast_id array() const
+  {
+    return array_;
+  }
+
+  inline ast_id index() const
+  {
+    return index_;
+  }
+
+protected:
+  ast_id array_;
+  ast_id index_;
+}; // ast_array_select
+
 /* \brief Range expression
  *
  * A pair of a most-significant bit and a least-significant bit of form
@@ -141,6 +171,76 @@ public:
 protected:
   ast_id hi_;
   ast_id lo_;
+};
+
+enum class sign_kind
+{
+  SIGN_MINUS = 1,
+};
+
+/* \brief Sign
+ *
+ */
+class ast_sign : public ast_node
+{
+public:
+  explicit ast_sign( sign_kind kind, ast_id expr )
+    : kind_( kind )
+    , expr_( expr )
+  {}
+
+  inline ast_id expr() const
+  {
+    return expr_;
+  }
+
+  inline sign_kind kind() const
+  {
+    return kind_;
+  }
+
+protected:
+  sign_kind kind_;
+  ast_id expr_;
+}; // ast_sign
+
+enum class expr_kind
+{
+  EXPR_ADD = 1,
+  EXPR_MUL = 2,
+};
+
+/* \brief Expression
+ *
+ */
+class ast_expression : public ast_node
+{
+public:
+  explicit ast_expression( expr_kind kind, ast_id left, ast_id right )
+    : kind_( kind )
+    , left_( left )
+    , right_( right )
+  {}
+
+  inline ast_id left() const
+  {
+    return left_;
+  }
+
+  inline ast_id right() const
+  {
+    return right_;
+  }
+
+  inline expr_kind kind() const
+  {
+    return kind_;
+  }
+
+protected:
+  expr_kind kind_;
+  ast_id left_;
+  ast_id right_;
 };
 
 /* \brief Input declaration
@@ -346,6 +446,26 @@ public:
   inline ast_id create_range_expression( ast_id hi, ast_id lo )
   {
     return create_node<ast_range_expression>( hi, lo );
+  }
+
+  inline ast_id create_array_select( ast_id array, ast_id index )
+  {
+    return create_node<ast_array_select>( array, index );
+  }
+
+  inline ast_id create_sum_expression( ast_id term, ast_id expr )
+  {
+    return create_node<ast_expression>( expr_kind::EXPR_ADD, term, expr );
+  }
+
+  inline ast_id create_negative_sign( ast_id expr )
+  {
+    return create_node<ast_sign>( sign_kind::SIGN_MINUS, expr );
+  }
+
+  inline ast_id create_mul_expression( ast_id term, ast_id expr )
+  {
+    return create_node<ast_expression>( expr_kind::EXPR_MUL, term, expr );
   }
 
   inline ast_id create_input_declaration( ast_id identifier_list )

--- a/include/lorina/verilog/ast_graph.hpp
+++ b/include/lorina/verilog/ast_graph.hpp
@@ -1,0 +1,487 @@
+/* lorina: C++ parsing library
+ * Copyright (C) 2018-2021  EPFL
+ * Copyright (C) 2022  Heinz Riener
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+  \file ast_graph.hpp
+  \brief Verilog AST Graph
+
+  \author Heinz Riener
+*/
+
+#pragma once
+
+namespace lorina
+{
+
+using ast_id = uint32_t;
+
+class ast_node
+{
+public:
+  explicit ast_node() = default;
+
+  virtual ~ast_node() {}
+}; // ast_node
+
+/* \brief Numeral
+ *
+ * A numeral.
+ *
+ */
+class ast_numeral : public ast_node
+{
+public:
+  explicit ast_numeral( const std::string value )
+    : value_( value )
+  {
+  }
+
+  inline std::string value() const
+  {
+    return value_;
+  }
+
+protected:
+  std::string value_;
+}; // ast_numeral
+
+/* \brief Identifier
+ *
+ * An identifier.
+ *
+ */
+class ast_identifier : public ast_node
+{
+public:
+  explicit ast_identifier( const std::string identifier )
+    : identifier_( identifier )
+  {
+  }
+
+  inline std::string identifier() const
+  {
+    return identifier_;
+  }
+
+protected:
+  std::string identifier_;
+}; // ast_identifier
+
+/* \brief Identifier list
+ *
+ * A list of identifiers of form
+ *   IDENTIFIER `,` ... `,` IDENTIFIER
+ *
+ */
+class ast_identifier_list : public ast_node
+{
+public:
+  explicit ast_identifier_list( const std::vector<ast_id>& identifiers )
+    : identifiers_( identifiers )
+  {
+  }
+
+  inline std::vector<ast_id> identifiers() const
+  {
+    return identifiers_;
+  }
+
+protected:
+  std::vector<ast_id> identifiers_;
+}; // ast_identifier_list
+
+/* \brief Range expression
+ *
+ * A pair of a most-significant bit and a least-significant bit of form
+ *   `[` MSB `:` LSB `]`
+ *
+ */
+class ast_range_expression : public ast_node
+{
+public:
+  explicit ast_range_expression( ast_id hi, ast_id lo )
+    : hi_( hi )
+    , lo_( lo )
+  {
+  }
+
+  inline ast_id hi() const
+  {
+    return hi_;
+  }
+
+  inline ast_id lo() const
+  {
+    return lo_;
+  }
+
+protected:
+  ast_id hi_;
+  ast_id lo_;
+};
+
+/* \brief Input declaration
+ *
+ * An input declaration of form
+ *   `input` ( `[` NUMERAL `:` NUMERAL `]` )? IDENTIFIER `,` ... `,` IDENTIFIER `;`
+ *
+ */
+class ast_input_declaration : public ast_node
+{
+public:
+  explicit ast_input_declaration( const std::vector<ast_id>& identifiers )
+    : word_level_( false )
+    , identifiers_( identifiers )
+  {
+  }
+
+  explicit ast_input_declaration( const std::vector<ast_id>& identifiers, ast_id hi, ast_id lo )
+    : word_level_( true )
+    , identifiers_( identifiers )
+    , hi_( hi )
+    , lo_( lo )
+  {
+  }
+
+  inline std::vector<ast_id> identifiers() const
+  {
+    return identifiers_;
+  }
+
+  inline ast_id hi() const
+  {
+    assert( word_level_ );
+    return hi_;
+  }
+
+  inline ast_id lo() const
+  {
+    assert( word_level_ );
+    return lo_;
+  }
+
+protected:
+  bool word_level_;
+  std::vector<ast_id> identifiers_;
+  ast_id hi_;
+  ast_id lo_;
+}; // ast_input_declaration
+
+/* \brief Output declaration
+ *
+ * An output declaration of form
+ *   `output` ( `[` NUMERAL `:` NUMERAL `]` )? IDENTIFIER `,` ... `,` IDENTIFIER `;`
+ *
+ */
+class ast_output_declaration : public ast_node
+{
+public:
+  explicit ast_output_declaration( const std::vector<ast_id>& identifiers )
+    : word_level_( false )
+    , identifiers_( identifiers )
+  {
+  }
+
+  explicit ast_output_declaration( const std::vector<ast_id>& identifiers, ast_id hi, ast_id lo )
+    : word_level_( true )
+    , identifiers_( identifiers )
+    , hi_( hi )
+    , lo_( lo )
+  {
+  }
+
+  inline std::vector<ast_id> identifiers() const
+  {
+    return identifiers_;
+  }
+
+  inline ast_id hi() const
+  {
+    assert( word_level_ );
+    return hi_;
+  }
+
+  inline ast_id lo() const
+  {
+    assert( word_level_ );
+    return lo_;
+  }
+
+protected:
+  bool word_level_;
+  std::vector<ast_id> identifiers_;
+  ast_id hi_;
+  ast_id lo_;
+}; // ast_output_declaration
+
+/* \brief Wire declaration
+ *
+ * An wire declaration of form
+ *   `wire` ( `[` NUMERAL `:` NUMERAL `]` )? IDENTIFIER `,` ... `,` IDENTIFIER `;`
+ *
+ */
+class ast_wire_declaration : public ast_node
+{
+public:
+  explicit ast_wire_declaration( const std::vector<ast_id>& identifiers )
+    : word_level_( false )
+    , identifiers_( identifiers )
+  {
+  }
+
+  explicit ast_wire_declaration( const std::vector<ast_id>& identifiers, ast_id hi, ast_id lo )
+    : word_level_( true )
+    , identifiers_( identifiers )
+    , hi_( hi )
+    , lo_( lo )
+  {
+  }
+
+  inline std::vector<ast_id> identifiers() const
+  {
+    return identifiers_;
+  }
+
+  inline ast_id hi() const
+  {
+    assert( word_level_ );
+    return hi_;
+  }
+
+  inline ast_id lo() const
+  {
+    assert( word_level_ );
+    return lo_;
+  }
+
+protected:
+  bool word_level_;
+  std::vector<ast_id> identifiers_;
+  ast_id hi_;
+  ast_id lo_;
+}; // ast_wire_declaration
+
+class verilog_ast_graph
+{
+public:
+  class ast_or_error
+  {
+  public:
+    explicit ast_or_error( ast_id ast )
+      : ast_( ast )
+    {
+      ast_ |= 0x80000000;
+    }
+
+    explicit ast_or_error()
+      : ast_( 0 )
+    {
+    }
+
+    inline ast_id ast() const
+    {
+      return ast_ & 0x7FFFFFFF;
+    }
+
+    inline operator bool() const
+    {
+      return valid();
+    }
+
+    inline bool valid() const
+    {
+      return ast_ & 0x80000000;
+    }
+
+  protected:
+    ast_id ast_;
+  };
+
+public:
+  explicit verilog_ast_graph() = default;
+
+  virtual ~verilog_ast_graph()
+  {
+    cleanup();
+  }
+
+  inline ast_id create_numeral( const std::string& numeral )
+  {
+    return create_node<ast_numeral>( numeral );
+  }
+
+  inline ast_id create_identifier( const std::string& identifier )
+  {
+    return create_node<ast_identifier>( identifier );
+  }
+
+  inline ast_id create_identifier_list( const std::vector<ast_id>& identifier_list )
+  {
+    return create_node<ast_identifier_list>( identifier_list );
+  }
+
+  inline ast_id create_range_expression( ast_id hi, ast_id lo )
+  {
+    return create_node<ast_range_expression>( hi, lo );
+  }
+
+  inline ast_id create_input_declaration( ast_id identifier_list )
+  {
+    assert( identifier_list < nodes_.size() );
+    if ( const ast_identifier_list* node = dynamic_cast<ast_identifier_list*>( nodes_[identifier_list] ) )
+    {
+      return create_node<ast_input_declaration>( node->identifiers() );
+    }
+    else if ( const ast_identifier* node = dynamic_cast<ast_identifier*>( nodes_[identifier_list] ) )
+    {
+      return create_node<ast_input_declaration>( std::vector<ast_id>( identifier_list ) );
+    }
+    else
+    {
+      assert( false && "unknown node type" );
+      std::abort();
+    }
+  }
+
+  inline ast_id create_input_declaration( ast_id identifier_list, ast_id range )
+  {
+    assert( identifier_list < nodes_.size() );
+    assert( range < nodes_.size() );
+    const ast_range_expression* range_expr = static_cast<ast_range_expression*>( nodes_[range] );
+    if ( const ast_identifier_list* node = dynamic_cast<ast_identifier_list*>( nodes_[identifier_list] ) )
+    {
+      return create_node<ast_input_declaration>( node->identifiers(), range_expr->hi(), range_expr->lo() );
+    }
+    else if ( const ast_identifier* node = dynamic_cast<ast_identifier*>( nodes_[identifier_list] ) )
+    {
+      return create_node<ast_input_declaration>( std::vector<ast_id>( identifier_list ), range_expr->hi(), range_expr->lo() );
+    }
+    else
+    {
+      assert( false && "unknown node type" );
+      std::abort();
+    }
+  }
+
+  inline ast_id create_output_declaration( ast_id identifier_list )
+  {
+    assert( identifier_list < nodes_.size() );
+    if ( const ast_identifier_list* node = dynamic_cast<ast_identifier_list*>( nodes_[identifier_list] ) )
+    {
+      return create_node<ast_output_declaration>( node->identifiers() );
+    }
+    else if ( const ast_identifier* node = dynamic_cast<ast_identifier*>( nodes_[identifier_list] ) )
+    {
+      return create_node<ast_output_declaration>( std::vector<ast_id>( identifier_list ) );
+    }
+    else
+    {
+      assert( false && "unknown node type" );
+      std::abort();
+    }
+  }
+
+  inline ast_id create_output_declaration( ast_id identifier_list, ast_id range )
+  {
+    assert( identifier_list < nodes_.size() );
+    assert( range < nodes_.size() );
+    const ast_range_expression* range_expr = static_cast<ast_range_expression*>( nodes_[range] );
+    if ( const ast_identifier_list* node = dynamic_cast<ast_identifier_list*>( nodes_[identifier_list] ) )
+    {
+      return create_node<ast_output_declaration>( node->identifiers(), range_expr->hi(), range_expr->lo() );
+    }
+    else if ( const ast_identifier* node = dynamic_cast<ast_identifier*>( nodes_[identifier_list] ) )
+    {
+      return create_node<ast_output_declaration>( std::vector<ast_id>( identifier_list ), range_expr->hi(), range_expr->lo() );
+    }
+    else
+    {
+      assert( false && "unknown node type" );
+      std::abort();
+    }
+  }
+
+  inline ast_id create_wire_declaration( ast_id identifier_list )
+  {
+    assert( identifier_list < nodes_.size() );
+    if ( const ast_identifier_list* node = dynamic_cast<ast_identifier_list*>( nodes_[identifier_list] ) )
+    {
+      return create_node<ast_wire_declaration>( node->identifiers() );
+    }
+    else if ( const ast_identifier* node = dynamic_cast<ast_identifier*>( nodes_[identifier_list] ) )
+    {
+      return create_node<ast_wire_declaration>( std::vector<ast_id>( identifier_list ) );
+    }
+    else
+    {
+      assert( false && "unknown node type" );
+      std::abort();
+    }
+  }
+
+  inline ast_id create_wire_declaration( ast_id identifier_list, ast_id range )
+  {
+    assert( identifier_list < nodes_.size() );
+    assert( range < nodes_.size() );
+    const ast_range_expression* range_expr = static_cast<ast_range_expression*>( nodes_[range] );
+    if ( const ast_identifier_list* node = dynamic_cast<ast_identifier_list*>( nodes_[identifier_list] ) )
+    {
+      return create_node<ast_wire_declaration>( node->identifiers(), range_expr->hi(), range_expr->lo() );
+    }
+    else if ( const ast_identifier* node = dynamic_cast<ast_identifier*>( nodes_[identifier_list] ) )
+    {
+      return create_node<ast_wire_declaration>( std::vector<ast_id>( identifier_list ), range_expr->hi(), range_expr->lo() );
+    }
+    else
+    {
+      assert( false && "unknown node type" );
+      std::abort();
+    }
+  }
+
+protected:
+  template<typename T, typename... Args>
+  inline ast_id create_node( Args... args )
+  {
+    const uint32_t index = nodes_.size();
+    nodes_.emplace_back( new T( args... ) );
+    return index;
+  }
+
+protected:
+  inline void cleanup()
+  {
+    for ( auto& node : nodes_ )
+    {
+      delete node;
+    }
+  }
+
+protected:
+  std::vector<ast_node*> nodes_;
+}; // verilog_ast_graph
+
+} // namespace lorina

--- a/include/lorina/verilog/ast_graph.hpp
+++ b/include/lorina/verilog/ast_graph.hpp
@@ -444,6 +444,40 @@ protected:
   std::vector<ast_id> parameters_;
 }; // ast_module_instantiation
 
+/* \brief Parameter declaration
+ *
+ */
+class ast_parameter_declaration : public ast_node
+{
+public:
+  explicit ast_parameter_declaration( ast_id identifier, ast_id expr )
+    : identifier_( identifier )
+    , expr_( expr )
+  {
+  }
+
+protected:
+  ast_id identifier_;
+  ast_id expr_;
+}; // ast_parameter_declaration
+
+/* \brief Assignment statement
+ *
+ */
+class ast_assignment : public ast_node
+{
+public:
+  explicit ast_assignment( ast_id signal, ast_id expr )
+    : signal_( signal )
+    , expr_( expr )
+  {
+  }
+
+protected:
+  ast_id signal_;
+  ast_id expr_;
+}; // ast_assignment
+
 class verilog_ast_graph
 {
 public:
@@ -672,6 +706,16 @@ public:
                                              const std::vector<ast_id>& parameters )
   {
     return create_node<ast_module_instantiation>( module_name, instance_name, port_assignment, parameters );
+  }
+
+  inline ast_id create_parameter_declaration( ast_id identifier, ast_id expr )
+  {
+    return create_node<ast_parameter_declaration>( identifier, expr );
+  }
+
+  inline ast_id create_assignment( ast_id signal, ast_id expr )
+  {
+    return create_node<ast_assignment>( signal, expr );
   }
 
 protected:

--- a/include/lorina/verilog/ast_graph.hpp
+++ b/include/lorina/verilog/ast_graph.hpp
@@ -416,6 +416,34 @@ protected:
   ast_id lo_;
 }; // ast_wire_declaration
 
+/* \brief Module instantiation
+ *
+ * A module instantiation of form
+ *   IDENTIFIER (ParameterAssignment)? IDENTIFIER `(` PortAssignment `)` `;`
+ * with
+ *   ParameterAssignment ::= `#` `(` ARITH_EXPR `,` ... `,` ARITH_EXPR `)`
+ *   PortAssignment ::= `.` IDENTIFIER(SIGNAL_REFERENCE) `,` ... `,` `.` IDENTIFIER(SIGNAL_REFERENCE).
+ */
+class ast_module_instantiation : public ast_node
+{
+public:
+  explicit ast_module_instantiation( ast_id module_name, ast_id instance_name,
+                                     const std::vector<std::pair<ast_id, ast_id>>& port_assignment,
+                                     const std::vector<ast_id>& parameters )
+    : module_name_( module_name )
+    , instance_name_( instance_name )
+    , port_assignment_( port_assignment )
+    , parameters_( parameters )
+  {
+  }
+
+protected:
+  ast_id module_name_;
+  ast_id instance_name_;
+  std::vector<std::pair<ast_id, ast_id>> port_assignment_;
+  std::vector<ast_id> parameters_;
+}; // ast_module_instantiation
+
 class verilog_ast_graph
 {
 public:
@@ -637,6 +665,13 @@ public:
       assert( false && "unknown node type" );
       std::abort();
     }
+  }
+
+  inline ast_id create_module_instantiation( ast_id module_name, ast_id instance_name,
+                                             const std::vector<std::pair<ast_id, ast_id>>& port_assignment,
+                                             const std::vector<ast_id>& parameters )
+  {
+    return create_node<ast_module_instantiation>( module_name, instance_name, port_assignment, parameters );
   }
 
 protected:

--- a/include/lorina/verilog/ast_graph.hpp
+++ b/include/lorina/verilog/ast_graph.hpp
@@ -478,6 +478,25 @@ protected:
   ast_id expr_;
 }; // ast_assignment
 
+/* \brief Module
+ *
+ */
+class ast_module : public ast_node
+{
+public:
+  explicit ast_module( ast_id module_name, const std::vector<ast_id>& args, const std::vector<ast_id>& decls )
+    : module_name_( module_name )
+    , args_( args )
+    , decls_( decls )
+  {
+  }
+
+protected:
+  ast_id module_name_;
+  std::vector<ast_id> args_;
+  std::vector<ast_id> decls_;
+}; // ast_module
+
 class verilog_ast_graph
 {
 public:
@@ -716,6 +735,11 @@ public:
   inline ast_id create_assignment( ast_id signal, ast_id expr )
   {
     return create_node<ast_assignment>( signal, expr );
+  }
+
+  inline ast_id create_module( ast_id module_name, const std::vector<ast_id>& args, const std::vector<ast_id>& decls )
+  {
+    return create_node<ast_module>( module_name, args, decls );
   }
 
 protected:

--- a/include/lorina/verilog/ast_graph.hpp
+++ b/include/lorina/verilog/ast_graph.hpp
@@ -208,6 +208,10 @@ enum class expr_kind
 {
   EXPR_ADD = 1,
   EXPR_MUL = 2,
+  EXPR_NOT = 3,
+  EXPR_AND = 4,
+  EXPR_OR = 5,
+  EXPR_XOR = 6,
 };
 
 /* \brief Expression
@@ -216,20 +220,27 @@ enum class expr_kind
 class ast_expression : public ast_node
 {
 public:
+  explicit ast_expression( expr_kind kind, ast_id left )
+    : kind_( kind )
+    , args_( {left} )
+  {}
+
   explicit ast_expression( expr_kind kind, ast_id left, ast_id right )
     : kind_( kind )
-    , left_( left )
-    , right_( right )
-  {}
+    , args_( {left, right} )
+  {
+  }
 
   inline ast_id left() const
   {
-    return left_;
+    assert( args_.size() >= 1 );
+    return args_[0];
   }
 
   inline ast_id right() const
   {
-    return right_;
+    assert( args_.size() >= 2 );
+    return args_[1];
   }
 
   inline expr_kind kind() const
@@ -239,8 +250,29 @@ public:
 
 protected:
   expr_kind kind_;
-  ast_id left_;
-  ast_id right_;
+  std::vector<ast_id> args_;
+};
+
+/* \brief System function
+ *
+ */
+class ast_system_function : public ast_node
+{
+public:
+  explicit ast_system_function( ast_id fun, const std::vector<ast_id>& args )
+    : fun_( fun )
+    , args_( args )
+  {
+  }
+
+  inline ast_id fun() const
+  {
+    return fun_;
+  }
+
+protected:
+  const ast_id fun_;
+  const std::vector<ast_id> args_;
 };
 
 /* \brief Input declaration
@@ -466,6 +498,31 @@ public:
   inline ast_id create_mul_expression( ast_id term, ast_id expr )
   {
     return create_node<ast_expression>( expr_kind::EXPR_MUL, term, expr );
+  }
+
+  inline ast_id create_not_expression( ast_id expr )
+  {
+    return create_node<ast_expression>( expr_kind::EXPR_NOT, expr );
+  }
+
+  inline ast_id create_and_expression( ast_id term, ast_id expr )
+  {
+    return create_node<ast_expression>( expr_kind::EXPR_AND, term, expr );
+  }
+
+  inline ast_id create_or_expression( ast_id term, ast_id expr )
+  {
+    return create_node<ast_expression>( expr_kind::EXPR_OR, term, expr );
+  }
+
+  inline ast_id create_xor_expression( ast_id term, ast_id expr )
+  {
+    return create_node<ast_expression>( expr_kind::EXPR_XOR, term, expr );
+  }
+
+  inline ast_id create_system_function( ast_id fun, const std::vector<ast_id>& args )
+  {
+    return create_node<ast_system_function>( fun, args );
   }
 
   inline ast_id create_input_declaration( ast_id identifier_list )

--- a/include/lorina/verilog/lexer.hpp
+++ b/include/lorina/verilog/lexer.hpp
@@ -385,11 +385,29 @@ public:
         }
         else if ( last_char_ == 'o' )
         {
-          assert( false );
+          numeral += last_char_;
+          consume(); // o
+          if ( is_oct_numeral_rest( last_char_ ) )
+          {
+            numeral += last_char_;
+            while ( is_oct_numeral_rest( consume() ) )
+            {
+              numeral += last_char_;
+            }
+          }
         }
         else if ( last_char_ == 'h' )
         {
-          assert( false );
+          numeral += last_char_;
+          consume(); // h
+          if ( is_hex_numeral_rest( last_char_ ) )
+          {
+            numeral += last_char_;
+            while ( is_hex_numeral_rest( consume() ) )
+            {
+              numeral += last_char_;
+            }
+          }
         }
       }
 
@@ -524,7 +542,17 @@ protected:
 
   inline bool is_numeral_rest(char ch)
   {
-    return ch >= '0' && ch <= '9';
+    return ( ch >= '0' && ch <= '9' ) || ch == '_';
+  }
+
+  inline bool is_oct_numeral_rest(char ch)
+  {
+    return ( ch >= '0' && ch <= '7' ) || ch == '_';
+  }
+
+  inline bool is_hex_numeral_rest(char ch)
+  {
+    return ( ch >= '0' && ch <= '9' ) || ( ch >= 'A' && ch <= 'F' ) || ( ch >= 'a' && ch <= 'f' ) || ch == '_';
   }
 
   inline bool is_literal_first(char ch)

--- a/include/lorina/verilog/parser.hpp
+++ b/include/lorina/verilog/parser.hpp
@@ -1,0 +1,346 @@
+/* lorina: C++ parsing library
+ * Copyright (C) 2018-2021  EPFL
+ * Copyright (C) 2022  Heinz Riener
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+  \file parser.hpp
+  \brief Verilog Parser
+
+  \author Heinz Riener
+*/
+
+#pragma once
+
+#include "../diagnostics.hpp"
+#include "ast_graph.hpp"
+#include "lexer.hpp"
+
+namespace lorina
+{
+
+class verilog_parser
+{
+public:
+  using Lexer = verilog_lexer<std::istream_iterator<char>>;
+
+public:
+  explicit verilog_parser( Lexer& lexer, verilog_ast_graph& ag, diagnostic_engine *diag )
+    : lexer_( lexer )
+    , ag_( ag )
+    , diag_( diag )
+  {
+    token_id_ = lexer_.next_token();
+  }
+
+public:
+  /* \brief Test if current token is a numeral
+   *
+   * \return Returns true iff current token is a numeral
+   */
+  inline bool is_numeral() const
+  {
+    const token s = lexer_.get( token_id_ );
+    return s.kind == token_kind::TK_NUMERAL;
+  }
+
+  /* \brief Consumes a numeral
+   *
+   * \return Returns AST of the numeral or an error
+   */
+  inline verilog_ast_graph::ast_or_error consume_numeral()
+  {
+    assert( is_numeral() );
+
+    const std::string& numeral = lexer_.get( token_id_ ).lexem;
+    token_id_ = lexer_.next_token();
+    return verilog_ast_graph::ast_or_error( ag_.create_numeral( numeral ) );
+  }
+
+  /* \brief Test if current token is the start of a range expression
+   *
+   * \return Returns true iff current token is the start of a range
+   *         expression
+   */
+  inline bool is_range_expression() const
+  {
+    return token_id_ == Lexer::TID_OP_LSQUARED;
+  }
+
+  /* \brief Consume a range expression
+   *
+   * A range expression is a pair of a most-significant bit and a
+   * least-significant bit.
+   *
+   * Production rule:
+   *   RANGE_EXPR ::= `[` NUMERAL `:` NUMERAL `]`
+   *
+   * Example:
+   *   [7:4]
+   */
+  inline verilog_ast_graph::ast_or_error consume_range_expression()
+  {
+    verilog_ast_graph::ast_or_error hi, lo;
+    assert( token_id_ == Lexer::TID_OP_LSQUARED );
+    token_id_ = lexer_.next_token(); // `[`
+
+    hi = consume_numeral(); // consume_arithmetic_expression()
+    if ( !hi )
+      goto error;
+
+    if ( token_id_ != Lexer::TID_OP_COLON )
+      goto error;
+    token_id_ = lexer_.next_token(); // `:`
+
+    lo = consume_numeral(); // consume_arithmetic_expression()
+    if ( !lo )
+      goto error;
+
+    if ( token_id_ != Lexer::TID_OP_RSQUARED )
+      goto error;
+    token_id_ = lexer_.next_token(); // `]`
+
+    return verilog_ast_graph::ast_or_error( ag_.create_range_expression( hi.ast(), lo.ast() ) );
+
+  error:
+    fmt::print("[e] could not parse a range expression.\n");
+    return verilog_ast_graph::ast_or_error();
+  }
+
+  /* \brief Test if current token is an identifier
+   *
+   * \return Returns true iff the current token is an identifier
+   */
+  inline bool is_identifier() const
+  {
+    const token s = lexer_.get( token_id_ );
+    return s.kind == token_kind::TK_IDENTIFIER;
+  }
+
+  /* \brief Consume an identifier
+   *
+   * \return Returns AST of the identifier or an error
+   */
+  inline verilog_ast_graph::ast_or_error consume_identifier()
+  {
+    assert( is_identifier() );
+
+    const std::string& identifier = lexer_.get( token_id_ ).lexem;
+    token_id_ = lexer_.next_token();
+    return verilog_ast_graph::ast_or_error( ag_.create_identifier( identifier ) );
+  }
+
+  /* \brief Consume a list of identifiers
+   *
+   * A list of identifiers separated by commas
+   *
+   * Production rule:
+   *   IDENTIFIER_LIST ::= IDENTIFIER `,` ... `,` IDENTIFIER
+   *
+   * Example:
+   *   a, b, c
+   */
+  inline verilog_ast_graph::ast_or_error consume_identifier_list()
+  {
+    verilog_ast_graph::ast_or_error identifier;
+    std::vector<ast_id> identifiers;
+
+    if ( !is_identifier() )
+      goto error;
+
+    /* first identifier */
+    identifier = consume_identifier();
+    if ( !identifier )
+      goto error;
+    identifiers.emplace_back( identifier.ast() );
+
+    /* other identifiers */
+    while ( token_id_ == Lexer::TID_OP_COMMA )
+    {
+      token_id_ = lexer_.next_token(); // `,`
+      if ( !is_identifier() )
+        goto error;
+
+      identifier = consume_identifier();
+      if ( !identifier )
+        goto error;
+      identifiers.emplace_back( identifier.ast() );
+    }
+    return verilog_ast_graph::ast_or_error( identifiers.size() == 1 ?
+                                            identifiers[0] : ag_.create_identifier_list( identifiers ) );
+
+  error:
+    fmt::print("[e] could not parse an identifier list.\n");
+    return verilog_ast_graph::ast_or_error();
+  }
+
+  /* \brief Consume input declaration
+   *
+   * An input declaration declares a list of identifiers either as
+   * bit-level or word-level inputs.
+   *
+   * Production rule:
+   *   INPUT_DECLARATIONS ::= `input` ( `[` MSB `:` LSB `]` )? IDENTIFIER `,` ... `,` IDENTIFIER `;`
+   */
+  inline verilog_ast_graph::ast_or_error consume_input_declaration()
+  {
+    verilog_ast_graph::ast_or_error identifiers, range;
+    bool word_level = false;
+
+    if ( token_id_ != Lexer::TID_KW_INPUT )
+      goto error;
+    token_id_ = lexer_.next_token(); // `input`
+
+    if ( is_range_expression() )
+    {
+      word_level = true;
+      range = consume_range_expression();
+      if ( !range )
+        goto error;
+    }
+
+    identifiers = consume_identifier_list();
+    if ( !identifiers )
+      goto error;
+
+    if ( token_id_ != Lexer::TID_OP_SEMICOLON )
+      goto error;
+    token_id_ = lexer_.next_token(); // `;`
+
+    if ( word_level )
+    {
+      return verilog_ast_graph::ast_or_error( ag_.create_input_declaration( identifiers.ast(), range.ast() ) );
+    }
+    else
+    {
+      return verilog_ast_graph::ast_or_error( ag_.create_input_declaration( identifiers.ast() ) );
+    }
+
+  error:
+    fmt::print("[e] could not parse input declaration.\n");
+    return verilog_ast_graph::ast_or_error();
+  }
+
+  /* \brief Consume output declaration
+   *
+   * An output declaration declares a list of identifiers either as
+   * bit-level or word-level outputs.
+   *
+   * Production rule:
+   *   OUTPUT_DECLARATIONS ::= `output` ( `[` MSB `:` LSB `]` )? IDENTIFIER `,` ... `,` IDENTIFIER `;`
+   */
+  inline verilog_ast_graph::ast_or_error consume_output_declaration()
+  {
+    verilog_ast_graph::ast_or_error identifiers, range;
+    bool word_level = false;
+
+    if ( token_id_ != Lexer::TID_KW_OUTPUT )
+      goto error;
+    token_id_ = lexer_.next_token(); // `output`
+
+    if ( is_range_expression() )
+    {
+      word_level = true;
+      range = consume_range_expression();
+      if ( !range )
+        goto error;
+    }
+
+    identifiers = consume_identifier_list();
+    if ( !identifiers )
+      goto error;
+
+    if ( token_id_ != Lexer::TID_OP_SEMICOLON )
+      goto error;
+    token_id_ = lexer_.next_token(); // `;`
+
+    if ( word_level )
+    {
+      return verilog_ast_graph::ast_or_error( ag_.create_output_declaration( identifiers.ast(), range.ast() ) );
+    }
+    else
+    {
+      return verilog_ast_graph::ast_or_error( ag_.create_output_declaration( identifiers.ast() ) );
+    }
+
+  error:
+    fmt::print("[e] could not parse output declaration.\n");
+    return verilog_ast_graph::ast_or_error();
+  }
+
+  /* \brief Consume wire declaration
+   *
+   * An wire declaration declares a list of identifiers either as
+   * bit-level or word-level wires.
+   *
+   * Production rule:
+   *   WIRE_DECLARATIONS ::= `wire` ( `[` MSB `:` LSB `]` )? IDENTIFIER `,` ... `,` IDENTIFIER `;`
+   */
+  inline verilog_ast_graph::ast_or_error consume_wire_declaration()
+  {
+    verilog_ast_graph::ast_or_error identifiers, range;
+    bool word_level = false;
+
+    if ( token_id_ != Lexer::TID_KW_WIRE )
+      goto error;
+    token_id_ = lexer_.next_token(); // `wire`
+
+    if ( is_range_expression() )
+    {
+      word_level = true;
+      range = consume_range_expression();
+      if ( !range )
+        goto error;
+    }
+
+    identifiers = consume_identifier_list();
+    if ( !identifiers )
+      goto error;
+
+    if ( token_id_ != Lexer::TID_OP_SEMICOLON )
+      goto error;
+    token_id_ = lexer_.next_token(); // `;`
+
+    if ( word_level )
+    {
+      return verilog_ast_graph::ast_or_error( ag_.create_wire_declaration( identifiers.ast(), range.ast() ) );
+    }
+    else
+    {
+      return verilog_ast_graph::ast_or_error( ag_.create_wire_declaration( identifiers.ast() ) );
+    }
+
+  error:
+    fmt::print("[e] could not parse wire declaration.\n");
+    return verilog_ast_graph::ast_or_error();
+  }
+
+protected:
+  Lexer& lexer_;
+  verilog_ast_graph& ag_;
+  diagnostic_engine *diag_;
+  uint32_t token_id_;
+};
+
+} // namespace lorina

--- a/test/verilog_parser.cpp
+++ b/test/verilog_parser.cpp
@@ -317,3 +317,30 @@ TEST_CASE( "Wire declaration", "[verilog]" )
     CHECK( ast );
   }
 }
+
+TEST_CASE( "Module instantiation", "[verilog]" )
+{
+  std::vector<std::string> sources;
+  sources.emplace_back( "mod_mul #(2) mul0(.i0(a),.i1(b),.o0(c));\n" );
+  sources.emplace_back( "mod_mul #(M)   mul0(.i0(a), .i1(b), .o0(c));\n" );
+  sources.emplace_back( "mod_add #(M,N) add0(.i0(a), .i1(b), .o0(c));\n" );
+  sources.emplace_back( "full_adder #(BITWIDTH) fa(.a(i[0]), .b(i[1]), .c(i[2]), .sum(o[0]), .carry(o[1]));\n" );
+
+  for ( const auto& source : sources )
+  {
+    std::istringstream in( source );
+    std::noskipws( in );
+
+    using Lexer = verilog_lexer<std::istream_iterator<char>>;
+    Lexer lexer( ( std::istream_iterator<char>(in) ), std::istream_iterator<char>());
+
+    verilog_ast_graph ag;
+
+    text_diagnostics consumer;
+    diagnostic_engine diag( &consumer );
+
+    verilog_parser parser( lexer, ag, &diag );
+    verilog_ast_graph::ast_or_error ast = parser.consume_module_instantiation();
+    CHECK( ast );
+  }
+}

--- a/test/verilog_parser.cpp
+++ b/test/verilog_parser.cpp
@@ -344,3 +344,54 @@ TEST_CASE( "Module instantiation", "[verilog]" )
     CHECK( ast );
   }
 }
+
+TEST_CASE( "Parameter declaration", "[verilog]" )
+{
+  std::vector<std::string> sources;
+  sources.emplace_back( "parameter WORD = 32;" );
+  sources.emplace_back( "parameter SIZE = 10;" );
+  sources.emplace_back( "parameter SIZE = N - 1;" );
+
+  for ( const auto& source : sources )
+  {
+    std::istringstream in( source );
+    std::noskipws( in );
+
+    using Lexer = verilog_lexer<std::istream_iterator<char>>;
+    Lexer lexer( ( std::istream_iterator<char>(in) ), std::istream_iterator<char>());
+
+    verilog_ast_graph ag;
+
+    text_diagnostics consumer;
+    diagnostic_engine diag( &consumer );
+
+    verilog_parser parser( lexer, ag, &diag );
+    verilog_ast_graph::ast_or_error ast = parser.consume_parameter_declaration();
+    CHECK( ast );
+  }
+}
+
+TEST_CASE( "Assignment", "[verilog]" )
+{
+  std::vector<std::string> sources;
+  sources.emplace_back( "assign maj = a & b | b & c | a & c;" );
+  sources.emplace_back( "assign x[2] = x[0] ^ x[1];" );
+
+  for ( const auto& source : sources )
+  {
+    std::istringstream in( source );
+    std::noskipws( in );
+
+    using Lexer = verilog_lexer<std::istream_iterator<char>>;
+    Lexer lexer( ( std::istream_iterator<char>(in) ), std::istream_iterator<char>());
+
+    verilog_ast_graph ag;
+
+    text_diagnostics consumer;
+    diagnostic_engine diag( &consumer );
+
+    verilog_parser parser( lexer, ag, &diag );
+    verilog_ast_graph::ast_or_error ast = parser.consume_assignment();
+    CHECK( ast );
+  }
+}

--- a/test/verilog_parser.cpp
+++ b/test/verilog_parser.cpp
@@ -1,0 +1,170 @@
+#include <catch.hpp>
+
+#include <lorina/verilog/parser.hpp>
+#include <sstream>
+#include <fmt/format.h>
+
+using namespace lorina;
+
+TEST_CASE( "Numeral", "[verilog]" )
+{
+  std::vector<std::string> sources;
+  sources.emplace_back( "0" );
+  sources.emplace_back( "1" );
+  sources.emplace_back( "10" );
+  // sources.emplace_back( "8'b11001100" );
+  // sources.emplace_back( "16'h7fff" );
+
+  for ( const auto& source : sources )
+  {
+    std::istringstream in( source );
+    std::noskipws( in );
+
+    using Lexer = verilog_lexer<std::istream_iterator<char>>;
+    Lexer lexer( ( std::istream_iterator<char>(in) ), std::istream_iterator<char>());
+
+    verilog_ast_graph ag;
+
+    text_diagnostics consumer;
+    diagnostic_engine diag( &consumer );
+
+    verilog_parser parser( lexer, ag, &diag );
+    verilog_ast_graph::ast_or_error ast = parser.consume_numeral();
+    CHECK( ast );
+  }
+}
+
+TEST_CASE( "Identifier", "[verilog]" )
+{
+  std::vector<std::string> sources;
+  sources.emplace_back( "a" );
+  sources.emplace_back( "b" );
+  sources.emplace_back( "c" );
+  sources.emplace_back( "test123" );
+  sources.emplace_back( "_test42" );
+  sources.emplace_back( "\test-" );
+
+  for ( const auto& source : sources )
+  {
+    std::istringstream in( source );
+    std::noskipws( in );
+
+    using Lexer = verilog_lexer<std::istream_iterator<char>>;
+    Lexer lexer( ( std::istream_iterator<char>(in) ), std::istream_iterator<char>());
+
+    verilog_ast_graph ag;
+
+    text_diagnostics consumer;
+    diagnostic_engine diag( &consumer );
+
+    verilog_parser parser( lexer, ag, &diag );
+    verilog_ast_graph::ast_or_error ast = parser.consume_identifier();
+    CHECK( ast );
+  }
+}
+
+TEST_CASE( "List of identifiers", "[verilog]" )
+{
+  std::vector<std::string> sources;
+  sources.emplace_back( "a" );
+  sources.emplace_back( "a, b, c" );
+
+  for ( const auto& source : sources )
+  {
+    std::istringstream in( source );
+    std::noskipws( in );
+
+    using Lexer = verilog_lexer<std::istream_iterator<char>>;
+    Lexer lexer( ( std::istream_iterator<char>(in) ), std::istream_iterator<char>());
+
+    verilog_ast_graph ag;
+
+    text_diagnostics consumer;
+    diagnostic_engine diag( &consumer );
+
+    verilog_parser parser( lexer, ag, &diag );
+    verilog_ast_graph::ast_or_error ast = parser.consume_identifier_list();
+    CHECK( ast );
+  }
+}
+
+TEST_CASE( "Input declaration", "[verilog]" )
+{
+  std::vector<std::string> sources;
+  sources.emplace_back( "input a;" );
+  sources.emplace_back( "input a, b, c;" );
+  sources.emplace_back( "input [7:0] a;" );
+  sources.emplace_back( "input [7:0] a, b, c;" );
+
+  for ( const auto& source : sources )
+  {
+    std::istringstream in( source );
+    std::noskipws( in );
+
+    using Lexer = verilog_lexer<std::istream_iterator<char>>;
+    Lexer lexer( ( std::istream_iterator<char>(in) ), std::istream_iterator<char>());
+
+    verilog_ast_graph ag;
+
+    text_diagnostics consumer;
+    diagnostic_engine diag( &consumer );
+
+    verilog_parser parser( lexer, ag, &diag );
+    verilog_ast_graph::ast_or_error ast = parser.consume_input_declaration();
+    CHECK( ast );
+  }
+}
+
+TEST_CASE( "Output declaration", "[verilog]" )
+{
+  std::vector<std::string> sources;
+  sources.emplace_back( "output a;" );
+  sources.emplace_back( "output a, b, c;" );
+  sources.emplace_back( "output [7:0] a;" );
+  sources.emplace_back( "output [7:0] a, b, c;" );
+
+  for ( const auto& source : sources )
+  {
+    std::istringstream in( source );
+    std::noskipws( in );
+
+    using Lexer = verilog_lexer<std::istream_iterator<char>>;
+    Lexer lexer( ( std::istream_iterator<char>(in) ), std::istream_iterator<char>());
+
+    verilog_ast_graph ag;
+
+    text_diagnostics consumer;
+    diagnostic_engine diag( &consumer );
+
+    verilog_parser parser( lexer, ag, &diag );
+    verilog_ast_graph::ast_or_error ast = parser.consume_output_declaration();
+    CHECK( ast );
+  }
+}
+
+TEST_CASE( "Wire declaration", "[verilog]" )
+{
+  std::vector<std::string> sources;
+  sources.emplace_back( "wire a;" );
+  sources.emplace_back( "wire a, b, c;" );
+  sources.emplace_back( "wire [7:0] a;" );
+  sources.emplace_back( "wire [7:0] a, b, c;" );
+
+  for ( const auto& source : sources )
+  {
+    std::istringstream in( source );
+    std::noskipws( in );
+
+    using Lexer = verilog_lexer<std::istream_iterator<char>>;
+    Lexer lexer( ( std::istream_iterator<char>(in) ), std::istream_iterator<char>());
+
+    verilog_ast_graph ag;
+
+    text_diagnostics consumer;
+    diagnostic_engine diag( &consumer );
+
+    verilog_parser parser( lexer, ag, &diag );
+    verilog_ast_graph::ast_or_error ast = parser.consume_wire_declaration();
+    CHECK( ast );
+  }
+}

--- a/test/verilog_parser.cpp
+++ b/test/verilog_parser.cpp
@@ -12,8 +12,9 @@ TEST_CASE( "Numeral", "[verilog]" )
   sources.emplace_back( "0" );
   sources.emplace_back( "1" );
   sources.emplace_back( "10" );
-  // sources.emplace_back( "8'b11001100" );
-  // sources.emplace_back( "16'h7fff" );
+  sources.emplace_back( "12'o7770" );
+  sources.emplace_back( "8'b110_01100" );
+  sources.emplace_back( "16'h7fff" );
 
   for ( const auto& source : sources )
   {

--- a/test/verilog_parser.cpp
+++ b/test/verilog_parser.cpp
@@ -155,6 +155,85 @@ TEST_CASE( "Arithmetic expression", "[verilog]" )
   }
 }
 
+TEST_CASE( "Expression", "[verilog]" )
+{
+  std::vector<std::string> sources;
+  sources.emplace_back( "x" );
+  sources.emplace_back( "(x)" );
+
+  sources.emplace_back( "x & y" );
+  sources.emplace_back( "(x) & y" );
+  sources.emplace_back( "x & (y)" );
+  sources.emplace_back( "(x & y)" );
+
+  sources.emplace_back( "x | y" );
+  sources.emplace_back( "(x) | y" );
+  sources.emplace_back( "x | (y)" );
+  sources.emplace_back( "(x | y)" );
+
+  sources.emplace_back( "x ^ y" );
+  sources.emplace_back( "(x) ^ y" );
+  sources.emplace_back( "x ^ (y)" );
+  sources.emplace_back( "(x ^ y)" );
+
+  sources.emplace_back( "x & y & z" );
+  sources.emplace_back( "x & y | z" );
+  sources.emplace_back( "x & y ^ z" );
+  sources.emplace_back( "x | y & z" );
+  sources.emplace_back( "x | y | z" );
+  sources.emplace_back( "x | y ^ z" );
+  sources.emplace_back( "x ^ y & z" );
+  sources.emplace_back( "x ^ y | z" );
+  sources.emplace_back( "x ^ y ^ z" );
+
+  sources.emplace_back( "x & (y | z)" );
+  sources.emplace_back( "(x | y) & z" );
+
+  sources.emplace_back( "~x" );
+  sources.emplace_back( "~(x)" );
+  sources.emplace_back( "(~x)" );
+  sources.emplace_back( "~~x" );
+  sources.emplace_back( "~a & b" );
+  sources.emplace_back( "a & ~b" );
+  sources.emplace_back( "~a & ~b" );
+  sources.emplace_back( "~(a & b)" );
+  sources.emplace_back( "(~a & b)" );
+  sources.emplace_back( "(a & ~b)" );
+  sources.emplace_back( "~(~a & b)" );
+  sources.emplace_back( "~(a & ~b)" );
+  sources.emplace_back( "~(~a & ~b)" );
+
+  sources.emplace_back( "(x&~y)|~z)" );
+  sources.emplace_back( "(foo^~bar)^baz)" );
+
+  sources.emplace_back( "$maj{a,b,c}" );
+  sources.emplace_back( "$maj{a,b,c,d,e}" );
+  sources.emplace_back( "$maj{$maj{a,b,c},b,c}}" );
+  sources.emplace_back( "$maj{a,$maj{a,b,c},c}}" );
+  sources.emplace_back( "$maj{a,b,$maj{a,b,c}}" );
+  sources.emplace_back( "$maj{~$maj{a,b,c},$maj{d,e,f},~$maj{g,h,i}}" );
+  sources.emplace_back( "$maj{a&b,c|d,e^f}" );
+  sources.emplace_back( "$maj{$and{a,b},$or{c,d},$xor{e,f}}" );
+
+  for ( const auto& source : sources )
+  {
+    std::istringstream in( source );
+    std::noskipws( in );
+
+    using Lexer = verilog_lexer<std::istream_iterator<char>>;
+    Lexer lexer( ( std::istream_iterator<char>(in) ), std::istream_iterator<char>());
+
+    verilog_ast_graph ag;
+
+    text_diagnostics consumer;
+    diagnostic_engine diag( &consumer );
+
+    verilog_parser parser( lexer, ag, &diag );
+    verilog_ast_graph::ast_or_error ast = parser.consume_expression();
+    CHECK( ast );
+  }
+}
+
 TEST_CASE( "Input declaration", "[verilog]" )
 {
   std::vector<std::string> sources;

--- a/test/verilog_parser.cpp
+++ b/test/verilog_parser.cpp
@@ -89,6 +89,72 @@ TEST_CASE( "List of identifiers", "[verilog]" )
   }
 }
 
+TEST_CASE( "Signal reference", "[verilog]" )
+{
+  std::vector<std::string> sources;
+  sources.emplace_back( "x" );
+  sources.emplace_back( "x[1]" );
+
+  for ( const auto& source : sources )
+  {
+    std::istringstream in( source );
+    std::noskipws( in );
+
+    using Lexer = verilog_lexer<std::istream_iterator<char>>;
+    Lexer lexer( ( std::istream_iterator<char>(in) ), std::istream_iterator<char>());
+
+    verilog_ast_graph ag;
+
+    text_diagnostics consumer;
+    diagnostic_engine diag( &consumer );
+
+    verilog_parser parser( lexer, ag, &diag );
+    verilog_ast_graph::ast_or_error ast = parser.consume_signal_reference();
+    CHECK( ast );
+  }
+}
+
+TEST_CASE( "Arithmetic expression", "[verilog]" )
+{
+  std::vector<std::string> sources;
+  sources.emplace_back( "x" );
+  sources.emplace_back( "x[0]" );
+  sources.emplace_back( "(x)" );
+
+  sources.emplace_back( "x*y" );
+  sources.emplace_back( "(-x)*y" );
+  sources.emplace_back( "x*(-y)" );
+  sources.emplace_back( "(-x)*(-y)" );
+  sources.emplace_back( "x[0]*y[1]" );
+
+  sources.emplace_back( "x+y" );
+  sources.emplace_back( "(-x)+y" );
+  sources.emplace_back( "x+(-y)" );
+  sources.emplace_back( "(-x)+(-y)" );
+  sources.emplace_back( "x[0]+y[1]" );
+
+  sources.emplace_back( "2*x+1" );
+  sources.emplace_back( "x-1" );
+
+  for ( const auto& source : sources )
+  {
+    std::istringstream in( source );
+    std::noskipws( in );
+
+    using Lexer = verilog_lexer<std::istream_iterator<char>>;
+    Lexer lexer( ( std::istream_iterator<char>(in) ), std::istream_iterator<char>());
+
+    verilog_ast_graph ag;
+
+    text_diagnostics consumer;
+    diagnostic_engine diag( &consumer );
+
+    verilog_parser parser( lexer, ag, &diag );
+    verilog_ast_graph::ast_or_error ast = parser.consume_arithmetic_expression();
+    CHECK( ast );
+  }
+}
+
 TEST_CASE( "Input declaration", "[verilog]" )
 {
   std::vector<std::string> sources;
@@ -96,6 +162,7 @@ TEST_CASE( "Input declaration", "[verilog]" )
   sources.emplace_back( "input a, b, c;" );
   sources.emplace_back( "input [7:0] a;" );
   sources.emplace_back( "input [7:0] a, b, c;" );
+  sources.emplace_back( "input [N-1:0] a;" );
 
   for ( const auto& source : sources )
   {
@@ -123,6 +190,7 @@ TEST_CASE( "Output declaration", "[verilog]" )
   sources.emplace_back( "output a, b, c;" );
   sources.emplace_back( "output [7:0] a;" );
   sources.emplace_back( "output [7:0] a, b, c;" );
+  sources.emplace_back( "output [N-1:0] a;" );
 
   for ( const auto& source : sources )
   {
@@ -150,6 +218,7 @@ TEST_CASE( "Wire declaration", "[verilog]" )
   sources.emplace_back( "wire a, b, c;" );
   sources.emplace_back( "wire [7:0] a;" );
   sources.emplace_back( "wire [7:0] a, b, c;" );
+  sources.emplace_back( "wire [N-1:0] a;" );
 
   for ( const auto& source : sources )
   {


### PR DESCRIPTION
This PR contains an experimental, new Verilog parsing engine that is supposed to replace the previous regexp-based parser. The parsing engine implements a simple recursive descent parser for a tiny subset of Verilog 1995.

Some implemented changes are listed below:
- The parser uses the Verilog lexer and avoids regular expressions. It is expected to parse more robustly and with improved runtime.
- The parser supports multiple entry points such that specific syntactic constructs, e.g., a Verilog expression, can be parsed in isolation. This improves the testability and debugability of the parsing engine.
- The parser does not directly invoke a reader visitor but builds an abstract syntax tree (AST) of the source code. More complex syntactic and semantic analyses, e.g. type checking or syntax rewriting, can be now implemented on the AST level. The AST is simple and WIP. It will likely be adapted depending on future applications. Implementing AST analysis passes is left for future work.
- Error handling has been mostly neglected in the new parsing engine because the Verilog lexer does not propagate file locations. However, the mechanism for reporting errors and diagnostics is already implemented.
