### PR TITLE
AST Visitor

### DIFF
--- a/include/lorina/verilog/ast_graph.hpp
+++ b/include/lorina/verilog/ast_graph.hpp
@@ -36,6 +36,55 @@
 namespace lorina
 {
 
+class verilog_ast_visitor;
+class verilog_ast_graph;
+
+class ast_node;
+class ast_numeral;
+class ast_identifier;
+class ast_identifier_list;
+class ast_array_select;
+class ast_range_expression;
+class ast_sign;
+class ast_expression;
+class ast_system_function;
+class ast_input_declaration;
+class ast_output_declaration;
+class ast_wire_declaration;
+class ast_module_instantiation;
+class ast_assignment;
+class ast_parameter_declaration;
+class ast_module;
+
+class verilog_ast_visitor
+{
+public:
+  explicit verilog_ast_visitor( const verilog_ast_graph* ag )
+    : ag_( ag )
+  {
+  }
+
+  virtual void visit( const ast_node& node ) { (void)node; }
+  virtual void visit( const ast_numeral& node ) { (void)node; }
+  virtual void visit( const ast_identifier& node ) { (void)node; }
+  virtual void visit( const ast_identifier_list& node ) { (void)node; }
+  virtual void visit( const ast_array_select& node ) { (void)node; }
+  virtual void visit( const ast_range_expression& node ) { (void)node; }
+  virtual void visit( const ast_sign& node ) { (void)node; }
+  virtual void visit( const ast_expression& node ) { (void)node; }
+  virtual void visit( const ast_system_function& node ) { (void)node; }
+  virtual void visit( const ast_input_declaration& node ) { (void)node; }
+  virtual void visit( const ast_output_declaration& node ) { (void)node; }
+  virtual void visit( const ast_wire_declaration& node ) { (void)node; }
+  virtual void visit( const ast_module_instantiation& node ) { (void)node; }
+  virtual void visit( const ast_assignment& node ) { (void)node; }
+  virtual void visit( const ast_module& node ) { (void)node; }
+  virtual void visit( const ast_parameter_declaration& node ) { (void)node; }
+
+protected:
+  const verilog_ast_graph* ag_;
+}; // verilog_ast_visitor
+
 using ast_id = uint32_t;
 
 class ast_node
@@ -44,6 +93,11 @@ public:
   explicit ast_node() = default;
 
   virtual ~ast_node() {}
+
+  virtual void accept( verilog_ast_visitor& v ) const
+  {
+    v.visit( *this );
+  }
 }; // ast_node
 
 /* \brief Numeral
@@ -54,7 +108,7 @@ public:
 class ast_numeral : public ast_node
 {
 public:
-  explicit ast_numeral( const std::string value )
+  explicit ast_numeral( const std::string& value )
     : value_( value )
   {
   }
@@ -64,8 +118,13 @@ public:
     return value_;
   }
 
+  virtual inline void accept(verilog_ast_visitor& v) const override
+  {
+    v.visit( *this );
+  }
+
 protected:
-  std::string value_;
+  const std::string value_;
 }; // ast_numeral
 
 /* \brief Identifier
@@ -76,7 +135,7 @@ protected:
 class ast_identifier : public ast_node
 {
 public:
-  explicit ast_identifier( const std::string identifier )
+  explicit ast_identifier( const std::string& identifier )
     : identifier_( identifier )
   {
   }
@@ -84,6 +143,11 @@ public:
   inline std::string identifier() const
   {
     return identifier_;
+  }
+
+  inline void accept(verilog_ast_visitor& v) const override
+  {
+    v.visit( *this );
   }
 
 protected:
@@ -109,8 +173,13 @@ public:
     return identifiers_;
   }
 
+  inline void accept(verilog_ast_visitor& v) const override
+  {
+    v.visit( *this );
+  }
+
 protected:
-  std::vector<ast_id> identifiers_;
+  const std::vector<ast_id> identifiers_;
 }; // ast_identifier_list
 
 /* \brief Array select
@@ -136,6 +205,11 @@ public:
   inline ast_id index() const
   {
     return index_;
+  }
+
+  virtual inline void accept(verilog_ast_visitor& v) const override
+  {
+    v.visit( *this );
   }
 
 protected:
@@ -166,6 +240,11 @@ public:
   inline ast_id lo() const
   {
     return lo_;
+  }
+
+  virtual inline void accept(verilog_ast_visitor& v) const override
+  {
+    v.visit( *this );
   }
 
 protected:
@@ -199,6 +278,11 @@ public:
     return kind_;
   }
 
+  virtual inline void accept(verilog_ast_visitor& v) const override
+  {
+    v.visit( *this );
+  }
+
 protected:
   sign_kind kind_;
   ast_id expr_;
@@ -223,7 +307,8 @@ public:
   explicit ast_expression( expr_kind kind, ast_id left )
     : kind_( kind )
     , args_( {left} )
-  {}
+  {
+  }
 
   explicit ast_expression( expr_kind kind, ast_id left, ast_id right )
     : kind_( kind )
@@ -248,6 +333,11 @@ public:
     return kind_;
   }
 
+  virtual inline void accept(verilog_ast_visitor& v) const override
+  {
+    v.visit( *this );
+  }
+
 protected:
   expr_kind kind_;
   std::vector<ast_id> args_;
@@ -268,6 +358,16 @@ public:
   inline ast_id fun() const
   {
     return fun_;
+  }
+
+  inline std::vector<ast_id> args() const
+  {
+    return args_;
+  }
+
+  virtual inline void accept(verilog_ast_visitor& v) const override
+  {
+    v.visit( *this );
   }
 
 protected:
@@ -298,6 +398,16 @@ public:
   {
   }
 
+  inline bool word_level() const
+  {
+    return word_level_;
+  }
+
+  inline bool bit_level() const
+  {
+    return !word_level_;
+  }
+
   inline std::vector<ast_id> identifiers() const
   {
     return identifiers_;
@@ -313,6 +423,11 @@ public:
   {
     assert( word_level_ );
     return lo_;
+  }
+
+  virtual inline void accept(verilog_ast_visitor& v) const override
+  {
+    v.visit( *this );
   }
 
 protected:
@@ -345,6 +460,16 @@ public:
   {
   }
 
+  inline bool word_level() const
+  {
+    return word_level_;
+  }
+
+  inline bool bit_level() const
+  {
+    return !word_level_;
+  }
+
   inline std::vector<ast_id> identifiers() const
   {
     return identifiers_;
@@ -360,6 +485,11 @@ public:
   {
     assert( word_level_ );
     return lo_;
+  }
+
+  virtual inline void accept(verilog_ast_visitor& v) const override
+  {
+    v.visit( *this );
   }
 
 protected:
@@ -392,6 +522,16 @@ public:
   {
   }
 
+  inline bool word_level() const
+  {
+    return word_level_;
+  }
+
+  inline bool bit_level() const
+  {
+    return !word_level_;
+  }
+
   inline std::vector<ast_id> identifiers() const
   {
     return identifiers_;
@@ -407,6 +547,11 @@ public:
   {
     assert( word_level_ );
     return lo_;
+  }
+
+  virtual inline void accept(verilog_ast_visitor& v) const override
+  {
+    v.visit( *this );
   }
 
 protected:
@@ -437,6 +582,31 @@ public:
   {
   }
 
+  ast_id module_name() const
+  {
+    return module_name_;
+  }
+
+  ast_id instance_name() const
+  {
+    return instance_name_;
+  }
+
+  std::vector<std::pair<ast_id, ast_id>> port_assignment() const
+  {
+    return port_assignment_;
+  }
+
+  std::vector<ast_id> parameters() const
+  {
+    return parameters_;
+  }
+
+  virtual inline void accept(verilog_ast_visitor& v) const override
+  {
+    v.visit( *this );
+  }
+
 protected:
   ast_id module_name_;
   ast_id instance_name_;
@@ -456,6 +626,21 @@ public:
   {
   }
 
+  ast_id identifier() const
+  {
+    return identifier_;
+  }
+
+  ast_id expr() const
+  {
+    return expr_;
+  }
+
+  virtual inline void accept(verilog_ast_visitor& v) const override
+  {
+    v.visit( *this );
+  }
+
 protected:
   ast_id identifier_;
   ast_id expr_;
@@ -471,6 +656,21 @@ public:
     : signal_( signal )
     , expr_( expr )
   {
+  }
+
+  ast_id signal() const
+  {
+    return signal_;
+  }
+
+  ast_id expr() const
+  {
+    return expr_;
+  }
+
+  virtual inline void accept(verilog_ast_visitor& v) const override
+  {
+    v.visit( *this );
   }
 
 protected:
@@ -489,6 +689,26 @@ public:
     , args_( args )
     , decls_( decls )
   {
+  }
+
+  ast_id module_name() const
+  {
+    return module_name_;
+  }
+
+  std::vector<ast_id> args() const
+  {
+    return args_;
+  }
+
+  std::vector<ast_id> decls() const
+  {
+    return decls_;
+  }
+
+  virtual inline void accept(verilog_ast_visitor& v) const override
+  {
+    v.visit( *this );
   }
 
 protected:
@@ -539,6 +759,23 @@ public:
   virtual ~verilog_ast_graph()
   {
     cleanup();
+  }
+
+  ast_node* node_ptr( ast_id id ) const
+  {
+    return nodes_.at( id );
+  }
+
+  template<typename T>
+  T* node_as_ptr( ast_id id ) const
+  {
+    return static_cast<T*>( node_ptr( id ) );
+  }
+
+  template<typename T>
+  const T& node_as_ref( ast_id id ) const
+  {
+    return *static_cast<T*>( node_ptr( id ) );
   }
 
   inline ast_id create_numeral( const std::string& numeral )
@@ -606,18 +843,19 @@ public:
     return create_node<ast_system_function>( fun, args );
   }
 
-  inline ast_id create_input_declaration( ast_id identifier_list )
+  inline ast_id create_input_declaration( ast_id id )
   {
-    assert( identifier_list < nodes_.size() );
-    if ( const ast_identifier_list* node = dynamic_cast<ast_identifier_list*>( nodes_[identifier_list] ) )
+    assert( id < nodes_.size() );
+
+    ast_node* node = nodes_[id];
+    if ( const ast_identifier_list* list = dynamic_cast<ast_identifier_list*>( node ) )
     {
-      (void)node;
-      return create_node<ast_input_declaration>( node->identifiers() );
+      return create_node<ast_input_declaration>( list->identifiers() );
     }
-    else if ( const ast_identifier* node = dynamic_cast<ast_identifier*>( nodes_[identifier_list] ) )
+    else if ( const ast_identifier* single = dynamic_cast<ast_identifier*>( node ) )
     {
-      (void)node;
-      return create_node<ast_input_declaration>( std::vector<ast_id>( identifier_list ) );
+      (void)single;
+      return create_node<ast_input_declaration, std::vector<ast_id>>( { id } );
     }
     else
     {
@@ -626,20 +864,21 @@ public:
     }
   }
 
-  inline ast_id create_input_declaration( ast_id identifier_list, ast_id range )
+  inline ast_id create_input_declaration( ast_id id, ast_id rid )
   {
-    assert( identifier_list < nodes_.size() );
-    assert( range < nodes_.size() );
-    const ast_range_expression* range_expr = static_cast<ast_range_expression*>( nodes_[range] );
-    if ( const ast_identifier_list* node = dynamic_cast<ast_identifier_list*>( nodes_[identifier_list] ) )
+    assert( id < nodes_.size() );
+    assert( rid < nodes_.size() );
+
+    ast_node* node = nodes_[id];
+    ast_range_expression* range = static_cast<ast_range_expression*>( nodes_[rid] );
+    if ( ast_identifier_list* list = dynamic_cast<ast_identifier_list*>( node ) )
     {
-      (void)node;
-      return create_node<ast_input_declaration>( node->identifiers(), range_expr->hi(), range_expr->lo() );
+      return create_node<ast_input_declaration, std::vector<ast_id>, ast_id, ast_id>( list->identifiers(), range->hi(), range->lo() );
     }
-    else if ( const ast_identifier* node = dynamic_cast<ast_identifier*>( nodes_[identifier_list] ) )
+    else if ( ast_identifier* single = dynamic_cast<ast_identifier*>( node ) )
     {
-      (void)node;
-      return create_node<ast_input_declaration>( std::vector<ast_id>( identifier_list ), range_expr->hi(), range_expr->lo() );
+      (void)single;
+      return create_node<ast_input_declaration, std::vector<ast_id>, ast_id, ast_id>( { id }, range->hi(), range->lo() );
     }
     else
     {
@@ -648,18 +887,19 @@ public:
     }
   }
 
-  inline ast_id create_output_declaration( ast_id identifier_list )
+  inline ast_id create_output_declaration( ast_id id )
   {
-    assert( identifier_list < nodes_.size() );
-    if ( const ast_identifier_list* node = dynamic_cast<ast_identifier_list*>( nodes_[identifier_list] ) )
+    assert( id < nodes_.size() );
+
+    ast_node* node = nodes_[id];
+    if ( const ast_identifier_list* list = dynamic_cast<ast_identifier_list*>( node ) )
     {
-      (void)node;
-      return create_node<ast_output_declaration>( node->identifiers() );
+      return create_node<ast_output_declaration>( list->identifiers() );
     }
-    else if ( const ast_identifier* node = dynamic_cast<ast_identifier*>( nodes_[identifier_list] ) )
+    else if ( const ast_identifier* single = dynamic_cast<ast_identifier*>( node ) )
     {
-      (void)node;
-      return create_node<ast_output_declaration>( std::vector<ast_id>( identifier_list ) );
+      (void)single;
+      return create_node<ast_output_declaration, std::vector<ast_id>>( { id } );
     }
     else
     {
@@ -668,20 +908,21 @@ public:
     }
   }
 
-  inline ast_id create_output_declaration( ast_id identifier_list, ast_id range )
+  inline ast_id create_output_declaration( ast_id id, ast_id rid )
   {
-    assert( identifier_list < nodes_.size() );
-    assert( range < nodes_.size() );
-    const ast_range_expression* range_expr = static_cast<ast_range_expression*>( nodes_[range] );
-    if ( const ast_identifier_list* node = dynamic_cast<ast_identifier_list*>( nodes_[identifier_list] ) )
+    assert( id < nodes_.size() );
+    assert( rid < nodes_.size() );
+
+    ast_node* node = nodes_[id];
+    ast_range_expression* range = static_cast<ast_range_expression*>( nodes_[rid] );
+    if ( ast_identifier_list* list = dynamic_cast<ast_identifier_list*>( node ) )
     {
-      (void)node;
-      return create_node<ast_output_declaration>( node->identifiers(), range_expr->hi(), range_expr->lo() );
+      return create_node<ast_output_declaration, std::vector<ast_id>, ast_id, ast_id>( list->identifiers(), range->hi(), range->lo() );
     }
-    else if ( const ast_identifier* node = dynamic_cast<ast_identifier*>( nodes_[identifier_list] ) )
+    else if ( ast_identifier* single = dynamic_cast<ast_identifier*>( node ) )
     {
-      (void)node;
-      return create_node<ast_output_declaration>( std::vector<ast_id>( identifier_list ), range_expr->hi(), range_expr->lo() );
+      (void)single;
+      return create_node<ast_output_declaration, std::vector<ast_id>, ast_id, ast_id>( { id }, range->hi(), range->lo() );
     }
     else
     {
@@ -690,18 +931,19 @@ public:
     }
   }
 
-  inline ast_id create_wire_declaration( ast_id identifier_list )
+  inline ast_id create_wire_declaration( ast_id id )
   {
-    assert( identifier_list < nodes_.size() );
-    if ( const ast_identifier_list* node = dynamic_cast<ast_identifier_list*>( nodes_[identifier_list] ) )
+    assert( id < nodes_.size() );
+
+    ast_node* node = nodes_[id];
+    if ( const ast_identifier_list* list = dynamic_cast<ast_identifier_list*>( node ) )
     {
-      (void)node;
-      return create_node<ast_wire_declaration>( node->identifiers() );
+      return create_node<ast_wire_declaration>( list->identifiers() );
     }
-    else if ( const ast_identifier* node = dynamic_cast<ast_identifier*>( nodes_[identifier_list] ) )
+    else if ( const ast_identifier* single = dynamic_cast<ast_identifier*>( node ) )
     {
-      (void)node;
-      return create_node<ast_wire_declaration>( std::vector<ast_id>( identifier_list ) );
+      (void)single;
+      return create_node<ast_wire_declaration, std::vector<ast_id>>( { id } );
     }
     else
     {
@@ -710,20 +952,21 @@ public:
     }
   }
 
-  inline ast_id create_wire_declaration( ast_id identifier_list, ast_id range )
+  inline ast_id create_wire_declaration( ast_id id, ast_id rid )
   {
-    assert( identifier_list < nodes_.size() );
-    assert( range < nodes_.size() );
-    const ast_range_expression* range_expr = static_cast<ast_range_expression*>( nodes_[range] );
-    if ( const ast_identifier_list* node = dynamic_cast<ast_identifier_list*>( nodes_[identifier_list] ) )
+    assert( id < nodes_.size() );
+    assert( rid < nodes_.size() );
+
+    ast_node* node = nodes_[id];
+    ast_range_expression* range = static_cast<ast_range_expression*>( nodes_[rid] );
+    if ( ast_identifier_list* list = dynamic_cast<ast_identifier_list*>( node ) )
     {
-      (void)node;
-      return create_node<ast_wire_declaration>( node->identifiers(), range_expr->hi(), range_expr->lo() );
+      return create_node<ast_wire_declaration, std::vector<ast_id>, ast_id, ast_id>( list->identifiers(), range->hi(), range->lo() );
     }
-    else if ( const ast_identifier* node = dynamic_cast<ast_identifier*>( nodes_[identifier_list] ) )
+    else if ( ast_identifier* single = dynamic_cast<ast_identifier*>( node ) )
     {
-      (void)node;
-      return create_node<ast_wire_declaration>( std::vector<ast_id>( identifier_list ), range_expr->hi(), range_expr->lo() );
+      (void)single;
+      return create_node<ast_wire_declaration, std::vector<ast_id>, ast_id, ast_id>( { id }, range->hi(), range->lo() );
     }
     else
     {
@@ -752,6 +995,17 @@ public:
   inline ast_id create_module( ast_id module_name, const std::vector<ast_id>& args, const std::vector<ast_id>& decls )
   {
     return create_node<ast_module>( module_name, args, decls );
+  }
+
+  void print() const
+  {
+    std::cout << "#nodes = " << nodes_.size() << std::endl;
+
+    uint32_t counter{0};
+    for ( const auto& node : nodes_ )
+    {
+      fmt::print( "{} {}\n", counter++, static_cast<void*>(node) );
+    }
   }
 
 protected:

--- a/include/lorina/verilog/ast_stringifier.hpp
+++ b/include/lorina/verilog/ast_stringifier.hpp
@@ -1,0 +1,374 @@
+/* lorina: C++ parsing library
+ * Copyright (C) 2018-2021  EPFL
+ * Copyright (C) 2022  Heinz Riener
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*!
+  \file ast_stringifier.hpp
+  \brief Translate a Verilog AST into a string
+
+  \author Heinz Riener
+*/
+
+#pragma once
+
+#include "ast_graph.hpp"
+#include <fmt/format.h>
+
+namespace lorina
+{
+
+class ast_stringifier : public verilog_ast_visitor
+{
+public:
+  explicit ast_stringifier( const verilog_ast_graph* ag )
+    : verilog_ast_visitor( ag )
+  {}
+
+  void emplace( const ast_node& node, const std::string& s )
+  {
+    str_.emplace( &node, s );
+  }
+
+  std::string string_of( ast_id id ) const
+  {
+    return str_.at( ag_->node_ptr( id ) );
+  }
+
+  void print() const
+  {
+    for ( const auto& s : str_ )
+    {
+      fmt::print( "{} \"{}\"\n", (void*)s.first, s.second );
+    }
+  }
+
+  void visit( const ast_node& node )
+  {
+    (void)node;
+    assert( false );
+  }
+
+  void visit( const ast_numeral& node )
+  {
+    emplace( node, node.value() );
+  }
+
+  void visit( const ast_identifier& node )
+  {
+    emplace( node, node.identifier() );
+  }
+
+  void visit( const ast_identifier_list& node )
+  {
+    std::vector<std::string> strings;
+    for ( const ast_id& id : node.identifiers() )
+    {
+      ag_->node_ptr( id )->accept( *this );
+      strings.emplace_back( str_[ag_->node_ptr( id )] );
+    }
+    emplace( node, fmt::to_string( fmt::join( strings, ", " ) ) );
+  }
+
+  void visit( const ast_array_select& node )
+  {
+    const ast_node* array = ag_->node_ptr( node.array() );
+    const ast_node* index = ag_->node_ptr( node.index() );
+    array->accept( *this );
+    index->accept( *this );
+    emplace( node, fmt::format( "{}[{}]", str_[array], str_[index] ) );
+  }
+
+  void visit( const ast_range_expression& node )
+  {
+    const ast_node* hi = ag_->node_ptr( node.hi() );
+    const ast_node* lo = ag_->node_ptr( node.lo() );
+    hi->accept( *this );
+    lo->accept( *this );
+    emplace( node, fmt::format( "[{}:{}]", str_[hi], str_[lo] ) );
+  }
+
+  void visit( const ast_sign& node )
+  {
+    const sign_kind kind = node.kind();
+    const ast_node* expr = ag_->node_ptr( node.expr() );
+    switch ( kind )
+    {
+    case sign_kind::SIGN_MINUS:
+      {
+        expr->accept( *this );
+        emplace( node, fmt::format( "(-{})", str_[expr] ) );
+      }
+      break;
+    default:
+      assert( false );
+    }
+  }
+
+  void visit( const ast_expression& node )
+  {
+    const expr_kind kind = node.kind();
+    switch ( kind )
+    {
+    case expr_kind::EXPR_NOT:
+      {
+        ag_->node_ptr( node.left() )->accept( *this );
+        emplace( node, fmt::format( "(~{})", str_[ag_->node_ptr( node.left() )] ) );
+      }
+      break;
+    case expr_kind::EXPR_AND:
+      {
+        ag_->node_ptr( node.left() )->accept( *this );
+        ag_->node_ptr( node.right() )->accept( *this );
+        emplace( node, fmt::format( "({} & {})",
+                                    str_[ag_->node_ptr( node.left() )],
+                                    str_[ag_->node_ptr( node.right() )] ) );
+      }
+      break;
+    case expr_kind::EXPR_OR:
+      {
+        ag_->node_ptr( node.left() )->accept( *this );
+        ag_->node_ptr( node.right() )->accept( *this );
+        emplace( node, fmt::format( "({} | {})",
+                                    str_[ag_->node_ptr( node.left() )],
+                                    str_[ag_->node_ptr( node.right() )] ) );
+      }
+      break;
+    case expr_kind::EXPR_XOR:
+      {
+        ag_->node_ptr( node.left() )->accept( *this );
+        ag_->node_ptr( node.right() )->accept( *this );
+        emplace( node, fmt::format( "({} ^ {})",
+                                    str_[ag_->node_ptr( node.left() )],
+                                    str_[ag_->node_ptr( node.right() )] ) );
+      }
+      break;
+    case expr_kind::EXPR_ADD:
+      {
+        ag_->node_ptr( node.left() )->accept( *this );
+        ag_->node_ptr( node.right() )->accept( *this );
+        emplace( node, fmt::format( "({} + {})",
+                                    str_[ag_->node_ptr( node.left() )],
+                                    str_[ag_->node_ptr( node.right() )] ) );
+      }
+      break;
+    case expr_kind::EXPR_MUL:
+      {
+        ag_->node_ptr( node.left() )->accept( *this );
+        ag_->node_ptr( node.right() )->accept( *this );
+        emplace( node, fmt::format( "({} * {})",
+                                    str_[ag_->node_ptr( node.left() )],
+                                    str_[ag_->node_ptr( node.right() )] ) );
+      }
+      break;
+    default:
+      assert( false );
+    }
+  }
+
+  void visit( const ast_system_function& node )
+  {
+    std::vector<std::string> args_strings;
+    for ( const auto& id : node.args() )
+    {
+      ag_->node_ptr( id )->accept( *this );
+      args_strings.emplace_back( str_[ag_->node_ptr( id )] );
+    }
+    ag_->node_ptr( node.fun() )->accept( *this );
+    emplace( node, fmt::format( "{}{{{}}}",
+                                str_[ag_->node_ptr( node.fun() )],
+                                fmt::join( args_strings, ", " ) ) );
+  }
+
+  void visit( const ast_input_declaration& node )
+  {
+    std::vector<std::string> strings;
+    for ( const ast_id& id : node.identifiers() )
+    {
+      const ast_node* identifier = ag_->node_ptr( id );
+      identifier->accept( *this );
+      strings.emplace_back( str_[identifier] );
+    }
+
+    if ( node.word_level() )
+    {
+      const ast_node* hi = ag_->node_ptr( node.hi() );
+      const ast_node* lo = ag_->node_ptr( node.lo() );
+      hi->accept( *this );
+      lo->accept( *this );
+      emplace( node,
+        fmt::format( "input [{}:{}] {};",
+                     str_[hi], str_[lo], fmt::join( strings, ", " ) ) );
+    }
+    else
+    {
+      emplace( node,
+        fmt::format( "input {};", fmt::join( strings, ", " ) ) );
+    }
+  }
+
+  void visit( const ast_output_declaration& node )
+  {
+    std::vector<std::string> strings;
+    for ( const ast_id& id : node.identifiers() )
+    {
+      const ast_node* identifier = ag_->node_ptr( id );
+      identifier->accept( *this );
+      strings.emplace_back( str_[identifier] );
+    }
+
+    if ( node.word_level() )
+    {
+      const ast_node* hi = ag_->node_ptr( node.hi() );
+      const ast_node* lo = ag_->node_ptr( node.lo() );
+      hi->accept( *this );
+      lo->accept( *this );
+      emplace( node,
+        fmt::format( "output [{}:{}] {};",
+                     str_[hi], str_[lo], fmt::join( strings, ", " ) ) );
+    }
+    else
+    {
+      emplace( node,
+        fmt::format( "output {};", fmt::join( strings, ", " ) ) );
+    }
+  }
+
+  void visit( const ast_wire_declaration& node )
+  {
+    std::vector<std::string> strings;
+    for ( const ast_id& id : node.identifiers() )
+    {
+      const ast_node* identifier = ag_->node_ptr( id );
+      identifier->accept( *this );
+      strings.emplace_back( str_[identifier] );
+    }
+
+    if ( node.word_level() )
+    {
+      const ast_node* hi = ag_->node_ptr( node.hi() );
+      const ast_node* lo = ag_->node_ptr( node.lo() );
+      hi->accept( *this );
+      lo->accept( *this );
+      emplace( node,
+        fmt::format( "wire [{}:{}] {};",
+                     str_[hi], str_[lo], fmt::join( strings, ", " ) ) );
+    }
+    else
+    {
+      emplace( node,
+        fmt::format( "wire {};", fmt::join( strings, ", " ) ) );
+    }
+  }
+
+  void visit( const ast_module_instantiation& node )
+  {
+    const ast_node* module_name = ag_->node_ptr( node.module_name() );
+    const ast_node* instance_name = ag_->node_ptr( node.instance_name() );
+
+    std::vector<std::string> port_assignments;
+    for ( const std::pair<ast_id,ast_id>& p : node.port_assignment() )
+    {
+      const ast_node* lhs = ag_->node_ptr( p.first );
+      const ast_node* rhs = ag_->node_ptr( p.second );
+      lhs->accept( *this );
+      rhs->accept( *this );
+      port_assignments.emplace_back(
+        fmt::format( ".{}({})", str_[lhs], str_[rhs] ) );
+    }
+
+    std::vector<std::string> parameters;
+    for ( const ast_id id : node.parameters() )
+    {
+      const ast_node* param_node = ag_->node_ptr( id );
+      param_node->accept( *this );
+      parameters.emplace_back( str_[param_node] );
+    }
+
+    module_name->accept( *this );
+    instance_name->accept( *this );
+
+    emplace( node,
+      fmt::format( "{} #({}) {}({});",
+                   str_[module_name],
+                   fmt::join( parameters, "," ),
+                   str_[instance_name],
+                   fmt::join( port_assignments, ", " ) ) );
+  }
+
+  void visit( const ast_assignment& node )
+  {
+    const ast_node* signal = ag_->node_ptr( node.signal() );
+    const ast_node* expr = ag_->node_ptr( node.expr() );
+    signal->accept( *this );
+    expr->accept( *this );
+    emplace( node, fmt::format( "assign {} = {};",
+                                str_[signal], str_[expr] ) );
+  }
+
+  void visit( const ast_parameter_declaration& node )
+  {
+    const ast_node* identifier = ag_->node_ptr( node.identifier() );
+    const ast_node* expr = ag_->node_ptr( node.expr() );
+    identifier->accept( *this );
+    expr->accept( *this );
+    emplace( node, fmt::format( "parameter {} = {};",
+                                str_[identifier], str_[expr] ) );
+  }
+
+  void visit( const ast_module& node )
+  {
+    const ast_node* module_name = ag_->node_ptr( node.module_name() );
+    module_name->accept( *this );
+
+    std::vector<std::string> args;
+    for ( ast_id arg : node.args() )
+    {
+      const ast_node* arg_node = ag_->node_ptr( arg );
+      arg_node->accept( *this );
+      args.emplace_back( str_[arg_node] );
+    }
+
+    std::vector<std::string> decls;
+    for ( ast_id decl : node.decls() )
+    {
+      const ast_node* decl_node = ag_->node_ptr( decl );
+      decl_node->accept( *this );
+      decls.emplace_back( str_[decl_node] + "\n" );
+    }
+
+    emplace( node,
+      fmt::format( "module {}({});\n{}endmodule\n",
+        str_[module_name],
+        fmt::join( args, ", " ),
+        fmt::join( decls, "" )
+      )
+    );
+  }
+
+protected:
+  std::unordered_map<const ast_node*, std::string> str_;
+}; // ast_stringifier
+
+} // namespace lorina

--- a/include/lorina/verilog/parser.hpp
+++ b/include/lorina/verilog/parser.hpp
@@ -234,7 +234,7 @@ public:
       token_id_ = lexer_.next_token(); // `]`
 
       return verilog_ast_graph::ast_or_error(
-               ag_.create_array_select( identifier.ast(), index ) );
+               ag_.create_array_select( identifier.ast(), index.ast() ) );
     }
     else
     {
@@ -1118,7 +1118,7 @@ public:
       goto error;
     token_id_ = lexer_.next_token(); // `endmodule`
 
-    return verilog_ast_graph::ast_or_error( ag_.create_module( module_name, args, decls ) );
+    return verilog_ast_graph::ast_or_error( ag_.create_module( module_name.ast(), args, decls ) );
 
   error:
     fmt::print("[e] could not parse module.\n");

--- a/test/ast_stringifier.cpp
+++ b/test/ast_stringifier.cpp
@@ -1,0 +1,477 @@
+#include <catch.hpp>
+
+#include <lorina/verilog/parser.hpp>
+#include <lorina/verilog/ast_stringifier.hpp>
+#include <sstream>
+#include <fmt/format.h>
+
+using namespace lorina;
+
+TEST_CASE( "AST Visitor", "[verilog]" )
+{
+  verilog_ast_graph ag;
+  ast_id n = ag.create_identifier( "test" );
+
+  ast_stringifier vis( &ag );
+  ag.node_ptr( n )->accept( vis );
+  // vis.print();
+
+  CHECK( vis.string_of( n ) == "test" );
+}
+
+TEST_CASE( "Visit identifier list", "[verilog]" )
+{
+  std::istringstream in( "a, b, c" );
+  std::noskipws( in );
+
+  using Lexer = verilog_lexer<std::istream_iterator<char>>;
+  Lexer lexer( ( std::istream_iterator<char>(in) ), std::istream_iterator<char>());
+
+  verilog_ast_graph ag;
+  ast_stringifier vis( &ag );
+
+  text_diagnostics consumer;
+  diagnostic_engine diag( &consumer );
+
+  verilog_parser parser( lexer, ag, &diag );
+  verilog_ast_graph::ast_or_error identifier_list = parser.consume_identifier_list();
+  assert( identifier_list );
+
+  ag.node_ptr( identifier_list.ast() )->accept( vis );
+  // vis.print();
+
+  CHECK( vis.string_of( identifier_list.ast() ) == "a, b, c" );
+}
+
+TEST_CASE( "Visit expression", "[verilog]" )
+{
+  std::vector<std::pair<std::string, std::string>> sources;
+  sources.emplace_back( std::make_pair( "x", "x" ) );
+  sources.emplace_back( std::make_pair( "(x)", "x" ) );
+
+  sources.emplace_back( std::make_pair( "x & y", "(x & y)" ) );
+  sources.emplace_back( std::make_pair( "(x) & y", "(x & y)" ) );
+  sources.emplace_back( std::make_pair( "x & (y)", "(x & y)" ) );
+  sources.emplace_back( std::make_pair( "(x & y)", "(x & y)" ) );
+
+  sources.emplace_back( std::make_pair( "x | y", "(x | y)" ) );
+  sources.emplace_back( std::make_pair( "(x) | y", "(x | y)" ) );
+  sources.emplace_back( std::make_pair( "x | (y)", "(x | y)" ) );
+  sources.emplace_back( std::make_pair( "(x | y)", "(x | y)" ) );
+
+  sources.emplace_back( std::make_pair( "x ^ y", "(x ^ y)" ) );
+  sources.emplace_back( std::make_pair( "(x) ^ y", "(x ^ y)" ) );
+  sources.emplace_back( std::make_pair( "x ^ (y)", "(x ^ y)" ) );
+  sources.emplace_back( std::make_pair( "(x ^ y)", "(x ^ y)" ) );
+
+  sources.emplace_back( std::make_pair( "x & y & z", "(x & (y & z))" ) );
+  sources.emplace_back( std::make_pair( "x & y | z", "((x & y) | z)" ) );
+  sources.emplace_back( std::make_pair( "x & y ^ z", "((x & y) ^ z)" ) );
+  sources.emplace_back( std::make_pair( "x | y & z", "(x | (y & z))" ) );
+  sources.emplace_back( std::make_pair( "x | y | z", "(x | (y | z))" ) );
+  sources.emplace_back( std::make_pair( "x | y ^ z", "((x | y) ^ z)" ) );
+  sources.emplace_back( std::make_pair( "x ^ y & z", "(x ^ (y & z))" ) );
+  sources.emplace_back( std::make_pair( "x ^ y | z", "(x ^ (y | z))" ) );
+  sources.emplace_back( std::make_pair( "x ^ y ^ z", "(x ^ (y ^ z))" ) );
+
+  sources.emplace_back( std::make_pair( "x & (y | z)", "(x & (y | z))" ) );
+  sources.emplace_back( std::make_pair( "(x | y) & z", "((x | y) & z)" ) );
+
+  sources.emplace_back( std::make_pair( "~x", "(~x)" ) );
+  sources.emplace_back( std::make_pair( "~(x)", "(~x)" ) );
+  sources.emplace_back( std::make_pair( "(~x)", "(~x)" ) );
+  sources.emplace_back( std::make_pair( "~~x", "(~(~x))" ) );
+  sources.emplace_back( std::make_pair( "~a & b", "((~a) & b)" ) );
+  sources.emplace_back( std::make_pair( "a & ~b", "(a & (~b))" ) );
+  sources.emplace_back( std::make_pair( "~a & ~b", "((~a) & (~b))" ) );
+  sources.emplace_back( std::make_pair( "~(a & b)", "(~(a & b))" ) );
+  sources.emplace_back( std::make_pair( "(~a & b)", "((~a) & b)" ) );
+  sources.emplace_back( std::make_pair( "(a & ~b)", "(a & (~b))" ) );
+  sources.emplace_back( std::make_pair( "~(~a & b)", "(~((~a) & b))" ) );
+  sources.emplace_back( std::make_pair( "~(a & ~b)", "(~(a & (~b)))" ) );
+  sources.emplace_back( std::make_pair( "~(~a & ~b)", "(~((~a) & (~b)))" ) );
+
+  sources.emplace_back( std::make_pair( "(x&~y)|~z)", "((x & (~y)) | (~z))" ) );
+  sources.emplace_back( std::make_pair( "(foo^~bar)^baz)", "((foo ^ (~bar)) ^ baz)" ) );
+
+  sources.emplace_back( std::make_pair( "$maj{a,b,c}", "$maj{a, b, c}" ) );
+  sources.emplace_back( std::make_pair( "$maj{a,b,c,d,e}", "$maj{a, b, c, d, e}" ) );
+  sources.emplace_back( std::make_pair( "$maj{$maj{a,b,c},b,c}", "$maj{$maj{a, b, c}, b, c}" ) );
+  sources.emplace_back( std::make_pair( "$maj{a,$maj{a,b,c},c}", "$maj{a, $maj{a, b, c}, c}" ) );
+  sources.emplace_back( std::make_pair( "$maj{a,b,$maj{a,b,c}}", "$maj{a, b, $maj{a, b, c}}" ) );
+  sources.emplace_back( std::make_pair( "$maj{~$maj{a,b,c},$maj{d,e,f},~$maj{g,h,i}}",
+                                        "$maj{(~$maj{a, b, c}), $maj{d, e, f}, (~$maj{g, h, i})}" ) );
+  sources.emplace_back( std::make_pair( "$maj{a&b,c|d,e^f}", "$maj{(a & b), (c | d), (e ^ f)}" ) );
+  sources.emplace_back( std::make_pair( "$maj{$and{a,b},$or{c,d},$xor{e,f}}",
+                                        "$maj{$and{a, b}, $or{c, d}, $xor{e, f}}" ) );
+
+  for ( const auto& source : sources )
+  {
+    std::istringstream in( source.first );
+    std::noskipws( in );
+
+    using Lexer = verilog_lexer<std::istream_iterator<char>>;
+    Lexer lexer( ( std::istream_iterator<char>(in) ), std::istream_iterator<char>());
+
+    verilog_ast_graph ag;
+    ast_stringifier vis( &ag );
+
+    text_diagnostics consumer;
+    diagnostic_engine diag( &consumer );
+
+    verilog_parser parser( lexer, ag, &diag );
+    verilog_ast_graph::ast_or_error expr = parser.consume_expression();
+    assert( expr );
+
+    ag.node_ptr( expr.ast() )->accept( vis );
+    CHECK( vis.string_of( expr.ast() ) == source.second );
+  }
+}
+
+TEST_CASE( "Visit arithmetic expression", "[verilog]" )
+{
+  std::vector<std::pair<std::string, std::string>> sources;
+  sources.emplace_back( std::make_pair( "x", "x" ) );
+  sources.emplace_back( std::make_pair( "x[0]", "x[0]" ) );
+  sources.emplace_back( std::make_pair( "y[1]", "y[1]" ) );
+  sources.emplace_back( std::make_pair( "(x)", "x" ) );
+
+  sources.emplace_back( std::make_pair( "x*y", "(x * y)" ) );
+  sources.emplace_back( std::make_pair( "(-x)*y", "((-x) * y)" ) );
+  sources.emplace_back( std::make_pair( "x*(-y)", "(x * (-y))" ) );
+  sources.emplace_back( std::make_pair( "(-x)*(-y)", "((-x) * (-y))" ) );
+  sources.emplace_back( std::make_pair( "x[0]*y[1]", "(x[0] * y[1])" ) );
+
+  sources.emplace_back( std::make_pair( "x+y", "(x + y)" ) );
+  sources.emplace_back( std::make_pair( "(-x)+y", "((-x) + y)" ) );
+  sources.emplace_back( std::make_pair( "x+(-y)", "(x + (-y))" ) );
+  sources.emplace_back( std::make_pair( "(-x)+(-y)", "((-x) + (-y))" ) );
+  sources.emplace_back( std::make_pair( "x[0]+y[1]", "(x[0] + y[1])" ) );
+
+  sources.emplace_back( std::make_pair( "2*x+1", "((2 * x) + 1)" ) );
+  sources.emplace_back( std::make_pair( "x-1", "(x + (-1))" ) );
+
+  for ( const auto& source : sources )
+  {
+    std::istringstream in( source.first );
+    std::noskipws( in );
+
+    using Lexer = verilog_lexer<std::istream_iterator<char>>;
+    Lexer lexer( ( std::istream_iterator<char>(in) ), std::istream_iterator<char>());
+
+    verilog_ast_graph ag;
+    ast_stringifier vis( &ag );
+
+    text_diagnostics consumer;
+    diagnostic_engine diag( &consumer );
+
+    verilog_parser parser( lexer, ag, &diag );
+    verilog_ast_graph::ast_or_error expr = parser.consume_arithmetic_expression();
+    assert( expr );
+
+    ag.node_ptr( expr.ast() )->accept( vis );
+    CHECK( vis.string_of( expr.ast() ) == source.second );
+  }
+}
+
+TEST_CASE( "Visit input declaration", "[verilog]" )
+{
+  std::vector<std::pair<std::string, std::string>> sources;
+  sources.emplace_back( std::make_pair( "input a;", "input a;" ) );
+  sources.emplace_back( std::make_pair( "input a,b,c;", "input a, b, c;" ) );
+  sources.emplace_back( std::make_pair( "input [7:0] a;", "input [7:0] a;" ) );
+  sources.emplace_back( std::make_pair( "input [7:0] a, b, c;", "input [7:0] a, b, c;" ) );
+  sources.emplace_back( std::make_pair( "input [N-1:0] a;", "input [(N + (-1)):0] a;" ) );
+
+  for ( const auto& source : sources )
+  {
+    std::istringstream in( source.first );
+    std::noskipws( in );
+
+    using Lexer = verilog_lexer<std::istream_iterator<char>>;
+    Lexer lexer( ( std::istream_iterator<char>(in) ), std::istream_iterator<char>());
+
+    verilog_ast_graph ag;
+    ast_stringifier vis( &ag );
+
+    text_diagnostics consumer;
+    diagnostic_engine diag( &consumer );
+
+    verilog_parser parser( lexer, ag, &diag );
+    verilog_ast_graph::ast_or_error expr = parser.consume_input_declaration();
+    assert( expr );
+
+    ag.node_ptr( expr.ast() )->accept( vis );
+    CHECK( vis.string_of( expr.ast() ) == source.second );
+  }
+}
+
+TEST_CASE( "Visit output declaration", "[verilog]" )
+{
+  std::vector<std::pair<std::string, std::string>> sources;
+  sources.emplace_back( std::make_pair( "output a;", "output a;" ) );
+  sources.emplace_back( std::make_pair( "output a, b, c;", "output a, b, c;" ) );
+  sources.emplace_back( std::make_pair( "output [7:0] a;", "output [7:0] a;" ) );
+  sources.emplace_back( std::make_pair( "output [7:0] a, b, c;", "output [7:0] a, b, c;" ) );
+  sources.emplace_back( std::make_pair( "output [N-1:0] a;", "output [(N + (-1)):0] a;" ) );
+
+  for ( const auto& source : sources )
+  {
+    std::istringstream in( source.first );
+    std::noskipws( in );
+
+    using Lexer = verilog_lexer<std::istream_iterator<char>>;
+    Lexer lexer( ( std::istream_iterator<char>(in) ), std::istream_iterator<char>());
+
+    verilog_ast_graph ag;
+    ast_stringifier vis( &ag );
+
+    text_diagnostics consumer;
+    diagnostic_engine diag( &consumer );
+
+    verilog_parser parser( lexer, ag, &diag );
+    verilog_ast_graph::ast_or_error expr = parser.consume_output_declaration();
+    assert( expr );
+
+    ag.node_ptr( expr.ast() )->accept( vis );
+    CHECK( vis.string_of( expr.ast() ) == source.second );
+  }
+}
+
+TEST_CASE( "Visit wire declaration", "[verilog]" )
+{
+  std::vector<std::pair<std::string, std::string>> sources;
+  sources.emplace_back( std::make_pair( "wire a;", "wire a;" ) );
+  sources.emplace_back( std::make_pair( "wire a, b, c;", "wire a, b, c;" ) );
+  sources.emplace_back( std::make_pair( "wire [7:0] a;", "wire [7:0] a;" ) );
+  sources.emplace_back( std::make_pair( "wire [7:0] a, b, c;", "wire [7:0] a, b, c;" ) );
+  sources.emplace_back( std::make_pair( "wire [N-1:0] a;", "wire [(N + (-1)):0] a;" ) );
+
+  for ( const auto& source : sources )
+  {
+    std::istringstream in( source.first );
+    std::noskipws( in );
+
+    using Lexer = verilog_lexer<std::istream_iterator<char>>;
+    Lexer lexer( ( std::istream_iterator<char>(in) ), std::istream_iterator<char>());
+
+    verilog_ast_graph ag;
+    ast_stringifier vis( &ag );
+
+    text_diagnostics consumer;
+    diagnostic_engine diag( &consumer );
+
+    verilog_parser parser( lexer, ag, &diag );
+    verilog_ast_graph::ast_or_error expr = parser.consume_wire_declaration();
+    assert( expr );
+
+    ag.node_ptr( expr.ast() )->accept( vis );
+    CHECK( vis.string_of( expr.ast() ) == source.second );
+  }
+}
+
+TEST_CASE( "Visit module instantiation", "[verilog]" )
+{
+  std::vector<std::pair<std::string, std::string>> sources;
+  sources.emplace_back(
+    std::make_pair( "mod_mul #(2) mul0(.i0(a),.i1(b),.o0(c));", "mod_mul #(2) mul0(.i0(a), .i1(b), .o0(c));" )
+  );
+  sources.emplace_back(
+    std::make_pair( "mod_mul #(M)   mul0(.i0(a), .i1(b), .o0(c));", "mod_mul #(M) mul0(.i0(a), .i1(b), .o0(c));" )
+  );
+  sources.emplace_back(
+    std::make_pair( "mod_add #(M,N) add0(.i0(a), .i1(b), .o0(c));", "mod_add #(M,N) add0(.i0(a), .i1(b), .o0(c));" )
+  );
+  sources.emplace_back(
+    std::make_pair( "full_adder #(BITWIDTH) fa(.a(i[0]), .b(i[1]), .c(i[2]), .sum(o[0]), .carry(o[1]));",
+                    "full_adder #(BITWIDTH) fa(.a(i[0]), .b(i[1]), .c(i[2]), .sum(o[0]), .carry(o[1]));" )
+  );
+
+  for ( const auto& source : sources )
+  {
+    std::istringstream in( source.first );
+    std::noskipws( in );
+
+    using Lexer = verilog_lexer<std::istream_iterator<char>>;
+    Lexer lexer( ( std::istream_iterator<char>(in) ), std::istream_iterator<char>());
+
+    verilog_ast_graph ag;
+    ast_stringifier vis( &ag );
+
+    text_diagnostics consumer;
+    diagnostic_engine diag( &consumer );
+
+    verilog_parser parser( lexer, ag, &diag );
+    verilog_ast_graph::ast_or_error expr = parser.consume_module_instantiation();
+    assert( expr );
+
+    ag.node_ptr( expr.ast() )->accept( vis );
+    CHECK( vis.string_of( expr.ast() ) == source.second );
+  }
+}
+
+TEST_CASE( "Visit parameter declaration", "[verilog]" )
+{
+  std::vector<std::pair<std::string, std::string>> sources;
+  sources.emplace_back( std::make_pair( "parameter WORD = 32;", "parameter WORD = 32;" ) );
+  sources.emplace_back( std::make_pair( "parameter SIZE = 10;", "parameter SIZE = 10;" ) );
+  sources.emplace_back( std::make_pair( "parameter SIZE = N - 1;", "parameter SIZE = (N + (-1));" ) );
+
+  for ( const auto& source : sources )
+  {
+    std::istringstream in( source.first );
+    std::noskipws( in );
+
+    using Lexer = verilog_lexer<std::istream_iterator<char>>;
+    Lexer lexer( ( std::istream_iterator<char>(in) ), std::istream_iterator<char>());
+
+    verilog_ast_graph ag;
+    ast_stringifier vis( &ag );
+
+    text_diagnostics consumer;
+    diagnostic_engine diag( &consumer );
+
+    verilog_parser parser( lexer, ag, &diag );
+    verilog_ast_graph::ast_or_error expr = parser.consume_parameter_declaration();
+    assert( expr );
+
+    ag.node_ptr( expr.ast() )->accept( vis );
+    CHECK( vis.string_of( expr.ast() ) == source.second );
+  }
+}
+
+TEST_CASE( "Visit assignment", "[verilog]" )
+{
+  std::vector<std::pair<std::string, std::string>> sources;
+  sources.emplace_back( std::make_pair( "assign maj = a & b | b & c | a & c;", "assign maj = ((a & b) | ((b & c) | (a & c)));" ) );
+  sources.emplace_back( std::make_pair( "assign x[2] = x[0] ^ x[1];", "assign x[2] = (x[0] ^ x[1]);" ) );
+
+  for ( const auto& source : sources )
+  {
+    std::istringstream in( source.first );
+    std::noskipws( in );
+
+    using Lexer = verilog_lexer<std::istream_iterator<char>>;
+    Lexer lexer( ( std::istream_iterator<char>(in) ), std::istream_iterator<char>());
+
+    verilog_ast_graph ag;
+    ast_stringifier vis( &ag );
+
+    text_diagnostics consumer;
+    diagnostic_engine diag( &consumer );
+
+    verilog_parser parser( lexer, ag, &diag );
+    verilog_ast_graph::ast_or_error expr = parser.consume_assignment();
+    assert( expr );
+
+    ag.node_ptr( expr.ast() )->accept( vis );
+    CHECK( vis.string_of( expr.ast() ) == source.second );
+  }
+}
+
+TEST_CASE( "Visit module", "[verilog]" )
+{
+  std::vector<std::pair<std::string, std::string>> sources;
+  sources.emplace_back( std::make_pair(
+      "module proto();\n"
+      "endmodule\n",
+      "module proto();\n"
+      "endmodule\n"
+    ) );
+  sources.emplace_back( std::make_pair(
+      "module proto(x);\n"
+      "endmodule\n",
+      "module proto(x);\n"
+      "endmodule\n"
+    ) );
+  sources.emplace_back( std::make_pair(
+      "module proto(x,y);\n"
+      "endmodule\n",
+      "module proto(x, y);\n"
+      "endmodule\n"
+    ) );
+  sources.emplace_back( std::make_pair(
+      "module buffer(x,y);\n"
+      "  input x;\n"
+      "  output y;\n"
+      "  assign y = x;\n"
+      "endmodule\n",
+      "module buffer(x, y);\n"
+      "input x;\n"
+      "output y;\n"
+      "assign y = x;\n"
+      "endmodule\n"
+    ) );
+  sources.emplace_back( std::make_pair(
+      "module majority(x0,x1,x2,y);\n"
+      "  input x0,x1,x2;\n"
+      "  output y;\n"
+      "  assign y = x0 & x1 | x1 & x2 | x0 & x2;\n"
+      "endmodule\n",
+      "module majority(x0, x1, x2, y);\n"
+      "input x0, x1, x2;\n"
+      "output y;\n"
+      "assign y = ((x0 & x1) | ((x1 & x2) | (x0 & x2)));\n"
+      "endmodule\n"
+    ) );
+  sources.emplace_back( std::make_pair(
+      "module majority(x0,x1,x2,x3,x4,y);\n"
+      "  input x0,x1,x2,x3,x4;\n"
+      "  output y;\n"
+      "  assign y = $maj{x0,x1,x2,x3,x4};\n"
+      "endmodule\n",
+      "module majority(x0, x1, x2, x3, x4, y);\n"
+      "input x0, x1, x2, x3, x4;\n"
+      "output y;\n"
+      "assign y = $maj{x0, x1, x2, x3, x4};\n"
+      "endmodule\n"
+    ) );
+  sources.emplace_back( std::make_pair(
+      "module majority(x,y);\n"
+      "  input [2:0] x;\n"
+      "  output y;\n"
+      "  assign y = x[0] & x[1] | x[1] & x[2] | x[0] & x[2];\n"
+      "endmodule\n",
+      "module majority(x, y);\n"
+      "input [2:0] x;\n"
+      "output y;\n"
+      "assign y = ((x[0] & x[1]) | ((x[1] & x[2]) | (x[0] & x[2])));\n"
+      "endmodule\n"
+    ) );
+  sources.emplace_back( std::make_pair(
+      "module full_adder(x,carry,sum);\n"
+      "  input [2:0] x;\n"
+      "  output carry, sum;\n"
+      "  assign sum = x[0]^x[1]^x[2];\n"
+      "  assign carry = $maj{x[0],x[1],x[2]};\n"
+      "endmodule\n",
+      "module full_adder(x, carry, sum);\n"
+      "input [2:0] x;\n"
+      "output carry, sum;\n"
+      "assign sum = (x[0] ^ (x[1] ^ x[2]));\n"
+      "assign carry = $maj{x[0], x[1], x[2]};\n"
+      "endmodule\n"
+    ) );
+
+  for ( const auto& source : sources )
+  {
+    std::istringstream in( source.first );
+    std::noskipws( in );
+
+    using Lexer = verilog_lexer<std::istream_iterator<char>>;
+    Lexer lexer( ( std::istream_iterator<char>(in) ), std::istream_iterator<char>());
+
+    verilog_ast_graph ag;
+    ast_stringifier vis( &ag );
+
+    text_diagnostics consumer;
+    diagnostic_engine diag( &consumer );
+
+    verilog_parser parser( lexer, ag, &diag );
+    verilog_ast_graph::ast_or_error expr = parser.consume_module();
+    assert( expr );
+
+    ag.node_ptr( expr.ast() )->accept( vis );
+    CHECK( vis.string_of( expr.ast() ) == source.second );
+  }
+}


### PR DESCRIPTION
This PR introduces a visitor mechanism for the `verilog_ast_graph` and implements a visitor called `ast_stringifier` that converts AST nodes into `std::string`s.