### PR TITLE
Supporting 2-to-1 mux in Verilog

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,24 +27,6 @@ jobs:
       run: |
         cd build
         ./test/run_tests
-  build-clang9:
-    name: Clang 9
-    runs-on: macOS-latest
-
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        submodules: true
-    - name: Build lorina
-      run: |
-        mkdir build
-        cd build
-        cmake -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DLORINA_TEST=ON ..
-        make run_tests
-    - name: Run tests
-      run: |
-        cd build
-        ./test/run_tests
   build-gcc10:
     name: GNU GCC 10
     runs-on: macOS-latest
@@ -75,7 +57,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DLORINA_TEST=ON ..
+        cmake -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DLORINA_TEST=ON ..
         make run_tests
     - name: Run tests
       run: |

--- a/include/lorina/verilog.hpp
+++ b/include/lorina/verilog.hpp
@@ -1,5 +1,5 @@
 /* lorina: C++ parsing library
- * Copyright (C) 2018-2021  EPFL
+ * Copyright (C) 2018-2022  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -267,6 +267,21 @@ public:
    * \param op3 operand3 of assignment
    */
   virtual void on_maj3( const std::string& lhs, const std::pair<std::string, bool>& op1, const std::pair<std::string, bool>& op2, const std::pair<std::string, bool>& op3 ) const
+  {
+    (void)lhs;
+    (void)op1;
+    (void)op2;
+    (void)op3;
+  }
+
+  /*! \brief Callback method for parsed 2-to-1 multiplexer gate `LHS = OP1 ? OP2 : OP3 ;`.
+   *
+   * \param lhs Left-hand side of assignment
+   * \param op1 operand1 of assignment
+   * \param op2 operand2 of assignment
+   * \param op3 operand3 of assignment
+   */
+  virtual void on_mux21( const std::string& lhs, const std::pair<std::string, bool>& op1, const std::pair<std::string, bool>& op2, const std::pair<std::string, bool>& op3 ) const
   {
     (void)lhs;
     (void)op1;
@@ -719,6 +734,21 @@ public:
                         ins.at( 2 ).first ? "~" : "", ins.at( 2 ).second );
   }
 
+  /*! \brief Callback method for writing a 2-to-1 multiplexer (ITE) assignment statement.
+   *
+   * \param out Output signal
+   * \param ins List of three input signals, in the order (if, then, else)
+   */
+  virtual void on_assign_mux21( std::string const& out, std::vector<std::pair<bool, std::string>> const& ins ) const
+  {
+    assert( ins.size() == 3u );
+    _os << fmt::format( "  assign {0} = {1}{2} ? {3}{4} : {5}{6} ;\n",
+                        out,
+                        ins.at( 0 ).first ? "~" : "", ins.at( 0 ).second,
+                        ins.at( 1 ).first ? "~" : "", ins.at( 1 ).second,
+                        ins.at( 2 ).first ? "~" : "", ins.at( 2 ).second );
+  }
+
   /*! \brief Callback method for writing an assignment statement with unknown operator.
    *
    * \param out Output signal
@@ -829,6 +859,11 @@ public:
                                       {
                                         assert( inputs.size() == 3u );
                                         reader.on_maj3( output, inputs[0], inputs[1], inputs[2] );
+                                      }
+                                      else if ( type == "mux21" )
+                                      {
+                                        assert( inputs.size() == 3u );
+                                        reader.on_mux21( output, inputs[0], inputs[1], inputs[2] );
                                       }
                                       else
                                       {
@@ -1566,6 +1601,13 @@ public:
       auto op = sm[3];
       if ( sm[6] != op )
       {
+        if ( sm[3] == "?" && sm[6] == ":" )
+        {
+          on_action.call_deferred<GATE_FN>( /* dependencies */ { arg0.first, arg1.first, arg2.first }, { lhs },
+                                            /* gate-function params */ std::make_tuple( args, lhs, "mux21" )
+                                          );
+          return true;
+        }
         return false;
       }
 

--- a/include/lorina/verilog_regex.hpp
+++ b/include/lorina/verilog_regex.hpp
@@ -1,5 +1,5 @@
 /* lorina: C++ parsing library
- * Copyright (C) 2018-2021  EPFL
+ * Copyright (C) 2018-2022  EPFL
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -42,7 +42,7 @@ namespace verilog_regex
 {
 static std::regex immediate_assign( R"(^(~)?\(?([[:alnum:]\[\]_']+)\)?$)" );
 static std::regex binary_expression( R"(^(~)?([[:alnum:]\[\]_']+)([&|^])(~)?([[:alnum:]\[\]_']+)$)" );
-static std::regex ternary_expression( R"(^(~)?([[:alnum:]\[\]_']+)([&|^])(~)?([[:alnum:]\[\]_']+)([&|^])(~)?([[:alnum:]\[\]_']+)$)" );
+static std::regex ternary_expression( R"(^(~)?([[:alnum:]\[\]_']+)([&|^?])(~)?([[:alnum:]\[\]_']+)([&|^:])(~)?([[:alnum:]\[\]_']+)$)" );
 static std::regex maj3_expression( R"(^\((~)?([[:alnum:]\[\]_']+)&(~)?([[:alnum:]\[\]_']+)\)\|\((~)?([[:alnum:]\[\]_']+)&(~)?([[:alnum:]\[\]_']+)\)\|\((~)?([[:alnum:]\[\]_']+)&(~)?([[:alnum:]\[\]_']+)\)$)" );
 static std::regex negated_binary_expression( R"(^~\((~)?([[:alnum:]\[\]_']+)([&|^])(~)?([[:alnum:]\[\]_']+)\)$)" );
 static std::regex const_size_range( R"(^(\d+):(\d+)$)" );

--- a/test/verilog.cpp
+++ b/test/verilog.cpp
@@ -129,6 +129,15 @@ public:
     ++_maj3;
   }
 
+  void on_mux21( const std::string& lhs, const std::pair<std::string, bool>& op1, const std::pair<std::string, bool>& op2, const std::pair<std::string, bool>& op3 ) const override
+  {
+    (void)lhs;
+    (void)op1;
+    (void)op2;
+    (void)op3;
+    ++_mux21;
+  }
+
   void on_endmodule() const override {}
 
   void on_comment( const std::string& comment ) const override
@@ -163,6 +172,7 @@ public:
   mutable uint32_t _ors3 = 0;
   mutable uint32_t _xors3 = 0;
   mutable uint32_t _maj3 = 0;
+  mutable uint32_t _mux21 = 0;
   mutable uint32_t _comments = 0;
   mutable uint32_t _parameter = 0;
   mutable uint32_t _instantiations = 0;
@@ -210,7 +220,7 @@ TEST_CASE( "Parse a simple Verilog file", "[verilog]" )
     "module top( y1, y2, y3, y4, y5, a, b, c ) ;\n"
     "  input a , b , c ;\n"
     "  output y1 , y2, y3, y4, y5, y6, y7, y8 ;\n"
-    "  wire zero, g0, g1 , g2 , g3 , g4, g5, g6, g7, g8 ;\n"
+    "  wire zero, g0, g1 , g2 , g3 , g4, g5, g6, g7, g8, g9 ;\n"
     "  assign zero = 0 ;\n"
     "  assign g0 = a ;\n"
     "  assign g1 = ~c ;\n"
@@ -221,6 +231,7 @@ TEST_CASE( "Parse a simple Verilog file", "[verilog]" )
     "  assign g6 = ~( a & b );\n"
     "  assign g7 = ~( a | b );\n"
     "  assign g8 = ~( a ^ b );\n"
+    "  assign g9 = g8 ? g3 : g4;"
     "  assign y1 = g4 ;\n"
     "  assign y2 = g5 ;\n"
     "  assign y3 = ~g0 & g1 & g2 ;\n"
@@ -228,7 +239,7 @@ TEST_CASE( "Parse a simple Verilog file", "[verilog]" )
     "  assign y5 = g3 ^ g4 ^ ~g5 ;\n"
     "  assign y6 = g6 ;\n"
     "  assign y7 = g7 ;\n"
-    "  assign y8 = g8 ;\n"
+    "  assign y8 = g9 ;\n"
     "endmodule\n";
 
   {
@@ -246,7 +257,7 @@ TEST_CASE( "Parse a simple Verilog file", "[verilog]" )
     CHECK( result == return_code::success );
     CHECK( reader._inputs == 3 );
     CHECK( reader._outputs == 8 );
-    CHECK( reader._wires == 10 );
+    CHECK( reader._wires == 11 );
     CHECK( reader._aliases == 8 );
     CHECK( reader._ands == 1 );
     CHECK( reader._nands == 1 );
@@ -257,6 +268,7 @@ TEST_CASE( "Parse a simple Verilog file", "[verilog]" )
     CHECK( reader._ors3 == 1 );
     CHECK( reader._xors3 == 1 );
     CHECK( reader._maj3 == 1 );
+    CHECK( reader._mux21 == 1 );
   }
 }
 


### PR DESCRIPTION
Adds support for parsing bit-level 2-to-1 MUXes in Verilog format (`assign y = a ? b : c;`).