### PR TITLE
Remove trailing whitespaces

### DIFF
--- a/docs/parsers.rst
+++ b/docs/parsers.rst
@@ -9,7 +9,7 @@ AIGER format
 .. toctree::
 
    aiger
-  
+
 .. doxygenclass:: lorina::aiger_reader
 
 BENCH format
@@ -97,5 +97,5 @@ VERILOG format
 .. toctree::
 
    verilog
-   
+
 .. doxygenclass:: lorina::verilog_reader

--- a/include/lorina/bristol.hpp
+++ b/include/lorina/bristol.hpp
@@ -203,7 +203,7 @@ private:
     if ( diag )
     {
       diag->report( diag_id::ERR_FILE_OPEN ).add_argument( filename );
-    }    
+    }
     return return_code::parse_error;
   }
   else

--- a/include/lorina/dimacs.hpp
+++ b/include/lorina/dimacs.hpp
@@ -136,7 +136,7 @@ static std::regex clause( R"(((-?[1-9][0-9]*)+ +)+0)" );
       return true;
     }
 
-    if ( found_spec == false ) 
+    if ( found_spec == false )
     {
       if ( diag )
       {
@@ -159,7 +159,7 @@ static std::regex clause( R"(((-?[1-9][0-9]*)+ +)+0)" );
       return false;
     }
 
-    for ( std::sregex_iterator i = clauses_begin; i != clauses_end; ++i ) 
+    for ( std::sregex_iterator i = clauses_begin; i != clauses_end; ++i )
     {
       std::smatch match = *i;
       std::stringstream ss( match[0].str() );
@@ -174,7 +174,7 @@ static std::regex clause( R"(((-?[1-9][0-9]*)+ +)+0)" );
         }
       }
       reader.on_clause( clause );
-    } 
+    }
     return true;
   } );
 

--- a/lib/infint/InfInt/InfInt.h
+++ b/lib/infint/InfInt/InfInt.h
@@ -1206,7 +1206,7 @@ inline bool InfInt::equalizeSigns()
             }
         }
     }
-    
+
     return isPositive;
 }
 
@@ -1232,7 +1232,7 @@ inline void InfInt::correct(bool justCheckLeadingZeros, bool hasValidSign)
     if (!justCheckLeadingZeros)
     {
         truncateToBase();
-        
+
         if (equalizeSigns())
         {
             pos = ((val.size() == 1 && val[0] == 0) || !hasValidSign) ? true : pos;
@@ -1246,7 +1246,7 @@ inline void InfInt::correct(bool justCheckLeadingZeros, bool hasValidSign)
             }
         }
     }
-    
+
     removeLeadingZeros();
 }
 

--- a/test/dimacs.cpp
+++ b/test/dimacs.cpp
@@ -131,15 +131,15 @@ TEST_CASE( "cnf_dimacs variables ending with 0", "[dimacs]" )
   "p cnf 10 2\n"
   "1 -10 8 0\n"
   "-2 3 10 0\n";
-  
+
   std::istringstream iss( dimacs );
-  
+
   dimacs_statistics stats;
   dimacs_statistics_reader reader( stats );
   diagnostic_consumer consumer;
   diagnostic_engine diag( &consumer );
   auto const result = read_dimacs( iss, reader, &diag );
-  
+
   CHECK( result == return_code::success );
   CHECK( stats.format == "cnf" );
   CHECK( stats.number_of_variables == 10 );

--- a/test/super.cpp
+++ b/test/super.cpp
@@ -34,7 +34,7 @@ public:
   {
     lib.genlib_name = genlib_name;
     lib.max_num_vars = max_num_vars;
-    lib.num_supergates = max_supergates; 
+    lib.num_supergates = max_supergates;
     lib.num_lines = num_lines;
   }
 
@@ -57,7 +57,7 @@ TEST_CASE( "instantiate super_reader", "[super]")
     "test.genlib\n"
     "3\n"
     "8\n"
-    "14\n"       
+    "14\n"
     "* and 1 0\n"
     "* and 2 3\n"
     "and 2 0\n"
@@ -170,7 +170,7 @@ TEST_CASE( "read SUPER format", "[super]")
     "test.genlib\n"
     "3\n"
     "2\n"
-    "6\n"       
+    "6\n"
     "* and2 1 0\n"
     "* or2 2 1\n"
     "and2 2 0\n"


### PR DESCRIPTION
I've found several trailing whitespaces in the code. I suppose they should be removed.