### PR TITLE
Update CIs

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_CXX_COMPILER=/usr/local/opt/gcc@9/bin/g++-9 -DLORINA_TEST=ON ..
+        cmake -DCMAKE_CXX_COMPILER=$(which g++-9) -DLORINA_TEST=ON ..
         make run_tests
     - name: Run tests
       run: |
@@ -39,7 +39,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_CXX_COMPILER=/usr/local/opt/gcc@10/bin/g++-10 -DLORINA_TEST=ON ..
+        cmake -DCMAKE_CXX_COMPILER=$(which g++-10) -DLORINA_TEST=ON ..
         make run_tests
     - name: Run tests
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -45,7 +45,7 @@ jobs:
       run: |
         cd build
         ./test/run_tests
-build-clang:
+  build-clang:
     name: Clang 12
     runs-on: macOS-latest
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,9 +9,9 @@ on:
     - master
 
 jobs:
-  build-gcc9:
-    name: GNU GCC 9
-    runs-on: macOS-latest
+  build-gcc10:
+    name: GNU GCC 10
+    runs-on: macOS-11
 
     steps:
     - uses: actions/checkout@v1
@@ -21,31 +21,31 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_CXX_COMPILER=$(which g++-9) -DLORINA_TEST=ON ..
-        make run_tests
-    - name: Run tests
-      run: |
-        cd build
-        ./test/run_tests
-  build-gcc10:
-    name: GNU GCC 10
-    runs-on: macOS-latest
-
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        submodules: true
-    - name: Build mockturtle
-      run: |
-        mkdir build
-        cd build
         cmake -DCMAKE_CXX_COMPILER=$(which g++-10) -DLORINA_TEST=ON ..
         make run_tests
     - name: Run tests
       run: |
         cd build
         ./test/run_tests
-  build-clang:
+  build-gcc11:
+    name: GNU GCC 11
+    runs-on: macOS-11
+
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - name: Build lorina
+      run: |
+        mkdir build
+        cd build
+        cmake -DCMAKE_CXX_COMPILER=$(which g++-11) -DLORINA_TEST=ON ..
+        make run_tests
+    - name: Run tests
+      run: |
+        cd build
+        ./test/run_tests
+build-clang:
     name: Clang 12
     runs-on: macOS-latest
 
@@ -53,7 +53,7 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: true
-    - name: Build mockturtle
+    - name: Build lorina
       run: |
         mkdir build
         cd build


### PR DESCRIPTION
This PR updates the outdated paths of the macOS CI.

Recent information on the runner images can be found at [1].

[1] https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md
